### PR TITLE
add error_hint on checkbox

### DIFF
--- a/lib/foundation_rails_helper/form_builder.rb
+++ b/lib/foundation_rails_helper/form_builder.rb
@@ -20,7 +20,7 @@ module FoundationRailsHelper
     def check_box(attribute, options = {})
       custom_label(attribute, options[:label]) do
         super(attribute, options)
-      end
+      end + error_and_hint(attribute)
     end
 
     def radio_button(attribute, tag_value, options = {})


### PR DESCRIPTION
If there are an error on a checkbox field there are no hint. This pull request add it.

Maybe an option can be pass to accept display this hint or not. I don't know what is prefer. I prefer this style. No guideline on zurb foundation documentation.
