### PR TITLE
Fix check_box label

### DIFF
--- a/lib/foundation_rails_helper/form_builder.rb
+++ b/lib/foundation_rails_helper/form_builder.rb
@@ -20,6 +20,7 @@ module FoundationRailsHelper
     def check_box(attribute, options = {})
       unless options[:label]
         options[:label] = object.class.human_attribute_name(attribute.to_s)
+      end
       custom_label(attribute, options[:label]) do
         super(attribute, options)
       end + error_and_hint(attribute)

--- a/spec/foundation_rails_helper/form_builder_spec.rb
+++ b/spec/foundation_rails_helper/form_builder_spec.rb
@@ -74,7 +74,7 @@ describe "FoundationRailsHelper::FormHelper" do
         node = Capybara.string builder.check_box(:active)
         node.should have_css('label[for="author_active"] input[type="hidden"][name="author[active]"][value="0"]')
         node.should have_css('label[for="author_active"] input[type="checkbox"][name="author[active]"]')
-        node.should have_css('label[for="author_active"]', :text => "Acctive")
+        node.should have_css('label[for="author_active"]', :text => "Active")
       end    
     end
   


### PR DESCRIPTION
Provides a default text value for a check_box label based on the attribute name when no label is passed as an argument.
