### PR TITLE
Set default checkbox label

### DIFF
--- a/lib/foundation_rails_helper/form_builder.rb
+++ b/lib/foundation_rails_helper/form_builder.rb
@@ -18,6 +18,9 @@ module FoundationRailsHelper
     end
 
     def check_box(attribute, options = {})
+      unless options[:label]
+        options[:label] = object.class.human_attribute_name(attribute.to_s)
+      end
       custom_label(attribute, options[:label]) do
         super(attribute, options)
       end + error_and_hint(attribute)

--- a/spec/foundation_rails_helper/form_builder_spec.rb
+++ b/spec/foundation_rails_helper/form_builder_spec.rb
@@ -74,6 +74,7 @@ describe "FoundationRailsHelper::FormHelper" do
         node = Capybara.string builder.check_box(:active)
         node.should have_css('label[for="author_active"] input[type="hidden"][name="author[active]"][value="0"]')
         node.should have_css('label[for="author_active"] input[type="checkbox"][name="author[active]"]')
+        node.should have_css('label[for="author_active"]', :text => "Active")
       end    
     end
   


### PR DESCRIPTION
If no label is passed as an argument then set a default label
for the checkbox based on the attribute name.
