### PR TITLE
Avoid label attribute in input_tag if you define the label

### DIFF
--- a/lib/foundation_rails_helper/form_builder.rb
+++ b/lib/foundation_rails_helper/form_builder.rb
@@ -19,6 +19,8 @@ module FoundationRailsHelper
 
     def check_box(attribute, options = {})
       custom_label(attribute, options[:label] || attribute.to_s.humanize, options[:label_options]) do
+        options.delete(:label)
+        options.delete(:label_options)
         super(attribute, options)
       end + error_and_hint(attribute)
     end
@@ -89,6 +91,8 @@ module FoundationRailsHelper
       html = custom_label(attribute, options[:label], options[:label_options])
       options[:class] ||= "medium"
       options[:class] = "#{options[:class]} input-text"
+      options.delete(:label)
+      options.delete(:label_options)
       html += yield(options)
       html += error_and_hint(attribute)
     end


### PR DESCRIPTION
If you define label or label_options in your options of input_tag it's
pass on your input helper and define like a attribute. We need delete
it.
