### PR TITLE
Fix label "for" when we are in a fields_for / Customize label for radio button

### DIFF
--- a/lib/foundation_rails_helper/form_builder.rb
+++ b/lib/foundation_rails_helper/form_builder.rb
@@ -14,7 +14,7 @@ module FoundationRailsHelper
     end
 
     def check_box(attribute, options = {})
-      custom_label(attribute, options[:label] || attribute.to_s.humanize, options[:label_options]) do
+      custom_label(attribute, options[:label], options[:label_options]) do
         options.delete(:label)
         options.delete(:label_options)
         super(attribute, options)
@@ -98,7 +98,10 @@ module FoundationRailsHelper
     end
 
     def field(attribute, options, &block)
-      html = custom_label(attribute, options[:label], options[:label_options])
+      html = ''.html_safe
+      if options[:label]
+        html = custom_label(attribute, options[:label], options[:label_options])
+      end
       options[:class] ||= "medium"
       options[:class] = "#{options[:class]} input-text"
       options.delete(:label)

--- a/spec/foundation_rails_helper/form_builder_spec.rb
+++ b/spec/foundation_rails_helper/form_builder_spec.rb
@@ -16,7 +16,7 @@ describe "FoundationRailsHelper::FormHelper" do
   describe "input generators" do
     it "should generate text_field input" do
       form_for(@author) do |builder|
-        node = Capybara.string builder.text_field(:login)
+        node = Capybara.string builder.label(:login) + builder.text_field(:login)
         node.should have_css('label[for="author_login"]', :text => "Login")
         node.should have_css('input.medium.input-text[type="text"][name="author[login]"]')
         node.find_field('author_login').value.should == @author.login
@@ -25,7 +25,7 @@ describe "FoundationRailsHelper::FormHelper" do
   
     it "should generate password_field input" do
       form_for(@author) do |builder|
-        node = Capybara.string builder.password_field(:password)
+        node = Capybara.string builder.label(:password) + builder.password_field(:password)
         node.should have_css('label[for="author_password"]', :text => "Password")
         node.should have_css('input.medium.input-text[type="password"][name="author[password]"]')
         node.find_field('author_password').value.should be_nil
@@ -34,7 +34,7 @@ describe "FoundationRailsHelper::FormHelper" do
   
     it "should generate email_field input" do
       form_for(@author) do |builder|
-        node = Capybara.string builder.email_field(:email)
+        node = Capybara.string builder.label(:email) + builder.email_field(:email)
         node.should have_css('label[for="author_email"]', :text => "Email")
         node.should have_css('input.medium.input-text[type="email"][name="author[email]"]')
         node.find_field('author_email').value.should == @author.email
@@ -43,7 +43,7 @@ describe "FoundationRailsHelper::FormHelper" do
 
     it "should generate text_area input" do
       form_for(@author) do |builder|
-        node = Capybara.string builder.text_area(:description)
+        node = Capybara.string builder.label(:description) + builder.text_area(:description)
         node.should have_css('label[for="author_description"]', :text => "Description")
         node.should have_css('textarea.medium.input-text[name="author[description]"]')
         node.find_field('author_description').value.strip.should == @author.description
@@ -52,7 +52,7 @@ describe "FoundationRailsHelper::FormHelper" do
   
     it "should generate file_field input" do
       form_for(@author) do |builder|
-        node = Capybara.string builder.file_field(:avatar)
+        node = Capybara.string builder.label(:avatar) + builder.file_field(:avatar)
         node.should have_css('label[for="author_avatar"]', :text => "Avatar")
         node.should have_css('input.medium.input-text[type="file"][name="author[avatar]"]')
         node.find_field('author_avatar').value.should  be_nil
@@ -61,7 +61,7 @@ describe "FoundationRailsHelper::FormHelper" do
     
     it "should generate select input" do
       form_for(@author) do |builder|
-        node = Capybara.string builder.select(:description, [["Choice #1", :a], ["Choice #2", :b]])
+        node = Capybara.string builder.label(:description) + builder.select(:description, [["Choice #1", :a], ["Choice #2", :b]])
         node.should have_css('label[for="author_description"]', :text => "Description")
         node.should have_css('select[name="author[description]"]')
         node.should have_css('select[name="author[description]"] option[value="a"]', :text => "Choice #1")
@@ -71,7 +71,7 @@ describe "FoundationRailsHelper::FormHelper" do
   
     it "should generate check_box input" do
       form_for(@author) do |builder|
-        node = Capybara.string builder.check_box(:active)
+        node = Capybara.string builder.label(:active) + builder.check_box(:active)
         node.should have_css('label[for="author_active"] input[type="hidden"][name="author[active]"][value="0"]')
         node.should have_css('label[for="author_active"] input[type="checkbox"][name="author[active]"]')
         node.should have_css('label[for="author_active"]', :text => "Active")
@@ -80,14 +80,14 @@ describe "FoundationRailsHelper::FormHelper" do
   
     it "should generate radio_button input" do
       form_for(@author) do |builder|
-        node = Capybara.string builder.radio_button(:active, "ok")
+        node = Capybara.string  builder.label(:active) + builder.radio_button(:active, "ok")
         node.should have_css('label[for="author_active_ok"] input[type="radio"][name="author[active]"]')
       end    
     end
   
     it "should generate date_select input" do
       form_for(@author) do |builder|
-        node = Capybara.string builder.date_select(:birthdate)
+        node = Capybara.string builder.label(:birthdate) + builder.date_select(:birthdate)
         node.should have_css('label[for="author_birthdate"]', :text => "Birthdate")
         %w(1 2 3).each {|i| node.should     have_css("select.medium.input-text[name='author[birthdate(#{i}i)]']") }
         node.should have_css('select#author_birthdate_1i option[selected="selected"][value="1969"]')


### PR DESCRIPTION
We cannot customize radio button's label, this commit add a parameter to fix this.

When we build radio button inside a fields_for, the radio_id in <label for="radio_id"> is wrong, now it take the id returned by the radio.
