### PR TITLE
Support for inline form labels

### DIFF
--- a/lib/foundation_rails_helper/form_builder.rb
+++ b/lib/foundation_rails_helper/form_builder.rb
@@ -3,6 +3,7 @@ require 'action_view/helpers'
 module FoundationRailsHelper
   class FormBuilder < ActionView::Helpers::FormBuilder
     include ActionView::Helpers::TagHelper
+    include ActionView::Context
     %w(file_field email_field text_field text_area telephone_field phone_field url_field number_field).each do |method_name|
       define_method(method_name) do |*args|
         attribute = args[0]
@@ -69,7 +70,15 @@ module FoundationRailsHelper
 
     def submit(value=nil, options={})
       options[:class] ||= "small radius success button"
-      super(value, options)
+      if @options[:inline]
+        content_tag :div, class: 'row' do
+          content_tag :div, class: 'eight columns offset-by-four' do
+            super(value, options)
+          end
+        end
+      else
+        super(value, options)
+      end
     end
 
   private
@@ -92,6 +101,7 @@ module FoundationRailsHelper
       text = block.call.html_safe + text if block_given?
       options ||= {}
       options[:class] ||= ""
+      options[:class] += " right inline" if @options[:inline]
       options[:class] += " error" if has_error?(attribute)
       label(attribute, text, options)
     end
@@ -104,15 +114,33 @@ module FoundationRailsHelper
     end
 
     def field(attribute, options, &block)
-      html = ''.html_safe
-      html = custom_label(attribute, options[:label], options[:label_options]) if false != options[:label]
+      label = custom_label(attribute, options[:label], options[:label_options]) if false != options[:label]
       options[:class] ||= "medium"
       options[:class] = "#{options[:class]} input-text"
       options[:class] += " error" if has_error?(attribute)
       options.delete(:label)
       options.delete(:label_options)
-      html += yield(options)
-      html += error_and_hint(attribute, options)
+      field = yield(options)
+      field << error_and_hint(attribute, options)
+
+      html = ''.html_safe
+      if @options[:inline]
+        html << inline_field(label, field)
+      else
+        html << label << field
+      end
+    end
+
+    def inline_field(label, field)
+      content_label = content_tag :div, class: 'four mobile-one columns' do
+                        label
+                      end
+      content_field = content_tag :div, class: 'eight mobile-three columns' do
+                        field
+                      end
+      content_tag :div, class: 'row' do
+        content_label + content_field
+      end
     end
   end
 end

--- a/spec/foundation_rails_helper/form_builder_spec.rb
+++ b/spec/foundation_rails_helper/form_builder_spec.rb
@@ -49,14 +49,14 @@ describe "FoundationRailsHelper::FormHelper" do
         node.find_field('author_email').value.should == @author.email
       end
     end
-    
+
     it "should generate url_field input" do
       form_for(@author) do |builder|
         node = Capybara.string builder.url_field(:url)
         node.should have_css('label[for="author_url"]', :text => "Url")
         node.should have_css('input.medium.input-text[type="url"][name="author[url]"]')
         node.find_field('author_url').value.should == @author.url
-      end    
+      end
     end
 
     it "should generate phone_field input" do
@@ -65,7 +65,7 @@ describe "FoundationRailsHelper::FormHelper" do
         node.should have_css('label[for="author_phone"]', :text => "Phone")
         node.should have_css('input.medium.input-text[type="tel"][name="author[phone]"]')
         node.find_field('author_phone').value.should == @author.phone
-      end    
+      end
     end
 
     it "should generate number_field input" do
@@ -74,7 +74,7 @@ describe "FoundationRailsHelper::FormHelper" do
         node.should have_css('label[for="author_some_number"]', :text => "Some number")
         node.should have_css('input.medium.input-text[type="number"][name="author[some_number]"]')
         node.find_field('author_some_number').value.should == @author.some_number
-      end    
+      end
     end
 
     it "should generate text_area input" do
@@ -153,6 +153,24 @@ describe "FoundationRailsHelper::FormHelper" do
       end
     end
 
+  end
+
+  describe "inline form" do
+    it "should generate inline text_field input" do
+      form_for(@author, :inline => true) do |builder|
+        node = Capybara.string builder.text_field(:login)
+        node.should have_css('div.row > div.four.mobile-one.columns > label[for="author_login"]', :text => "Login")
+        node.should have_css('div.row > div.eight.mobile-three.columns > input.medium.input-text[type="text"][name="author[login]"]')
+        node.find_field('author_login').value.should == @author.login
+      end
+    end
+
+    it "should generate submit" do
+      form_for(@author, :inline => true) do |builder|
+        node = Capybara.string builder.submit
+        node.should have_css('div.row > div.eight.columns.offset-by-four > input[type="submit"]')
+      end
+    end
   end
 
   describe "errors generator" do


### PR DESCRIPTION
Howdy

This PR adds basic support for inline form labels.

Usage:

``` ruby
form_for(@article, inline: true) do |f|
  f.text_field :title
  f.text_field :something
  f.submit
end
```

Which will look like this:
![23 02 13_20_51-Bildschirmkopie](https://f.cloud.github.com/assets/480921/188517/7ddf5eea-7df2-11e2-85c6-892e47646000.png)
