### PR TITLE
Add data-alert attribute

### DIFF
--- a/lib/foundation_rails_helper/flash_helper.rb
+++ b/lib/foundation_rails_helper/flash_helper.rb
@@ -16,7 +16,7 @@ module FoundationRailsHelper
       key_matching = DEFAULT_KEY_MATCHING.merge(key_matching)
       
       flash.inject "" do |message, (key, value)|
-        message += content_tag :div, :class => "alert-box #{key_matching[key] || :standard}" do
+        message += content_tag :div, :data => { :alert => "" }, :class => "alert-box #{key_matching[key] || :standard}" do
           (value + link_to("&times;".html_safe, "#", :class => :close)).html_safe
         end
       end.html_safe


### PR DESCRIPTION
Add empty data-alert attribute to content_tag. This is in order to fix closing of flash notices in foundation 4.
