### PR TITLE
Loosen version requirements on Railties and ActionPack

### DIFF
--- a/foundation_rails_helper.gemspec
+++ b/foundation_rails_helper.gemspec
@@ -4,8 +4,8 @@ require File.expand_path('../lib/foundation_rails_helper/version', __FILE__)
 Gem::Specification.new do |gem|
   gem.authors       = ["Sebastien Gruhier"]
   gem.email         = ["sebastien.gruhier@xilinus.com"]
-  gem.description   = %q{Rails 3 for zurb foundation CSS framework. Form builder, flash message, ...}
-  gem.summary       = %q{Rails 3 helpers for zurb foundation CSS framework}
+  gem.description   = %q{Rails for zurb foundation CSS framework. Form builder, flash message, ...}
+  gem.summary       = %q{Rails helpers for zurb foundation CSS framework}
   gem.homepage      = "http://github.com/sgruhier/foundation_rails_helper"
 
   gem.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
@@ -15,8 +15,8 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = FoundationRailsHelper::VERSION
 
-  gem.add_dependency 'railties', '~> 3.0'
-  gem.add_dependency "actionpack", '~> 3.0'
+  gem.add_dependency 'railties', '>= 3.0'
+  gem.add_dependency "actionpack", '>= 3.0'
   gem.add_development_dependency "rspec-rails"
   gem.add_development_dependency "capybara"
 end


### PR DESCRIPTION
I haven't noticed any adverse behavior with Rails 4, simply by allowing Railties and ActionPack `>= 3.0` instead of `~> 3.0`. Should be safe to loosen those requirements and make it usable with Rails 4.
