### PR TITLE
Adds the text option to the radio_button to customize the label.

### DIFF
--- a/lib/foundation_rails_helper/form_builder.rb
+++ b/lib/foundation_rails_helper/form_builder.rb
@@ -23,8 +23,8 @@ module FoundationRailsHelper
 
     def radio_button(attribute, tag_value, options = {})
       options[:for] ||= "#{object.class.to_s.downcase}_#{attribute}_#{tag_value}"
-      l = label(attribute, options)
       c = super(attribute, tag_value, options)
+      l = label(attribute, options.delete(:text), options)
       l.gsub(/(for=\"\w*\"\>)/, "\\1#{c} ").html_safe
     end
 

--- a/spec/foundation_rails_helper/form_builder_spec.rb
+++ b/spec/foundation_rails_helper/form_builder_spec.rb
@@ -129,6 +129,14 @@ describe "FoundationRailsHelper::FormHelper" do
       end
     end
 
+    it "should generate radio_button input" do
+      form_for(@author) do |builder|
+        node = Capybara.string builder.radio_button(:active, true, text: "Functioning")
+        node.should have_css('input[type="radio"][name="author[active]"]')
+        node.should have_css('label[for="author_active_true"]', text: "Functioning")
+      end
+    end
+
     it "should generate date_select input" do
       form_for(@author) do |builder|
         node = Capybara.string builder.label(:birthdate) + builder.date_select(:birthdate)


### PR DESCRIPTION
Hello,

This pull requests adds a text option to the radio button to customize the label text. Example:

``` ruby
f.radio_button(:private, false, text: 'Publico')
```

Would generate both the radio button with the previous functionality and a label with the text "Publico"
