### PR TITLE
Added success(success) and error(alert) to acceptable flash options

### DIFF
--- a/lib/foundation_rails_helper/flash_helper.rb
+++ b/lib/foundation_rails_helper/flash_helper.rb
@@ -11,6 +11,8 @@ module FoundationRailsHelper
       :notice    => :success,
       :info      => :standard,
       :secondary => :secondary,
+      :success   => :success,
+      :error     => :alert
     }
     def display_flash_messages(key_matching = {})
       key_matching = DEFAULT_KEY_MATCHING.merge(key_matching)


### PR DESCRIPTION
I like to use `flash[:success]` and `flash[:error]`.  I added them to the available options so your flash helper works for them.  Success maps to success, error maps to alert.
