### PR TITLE
Form builder is friendly toward forms without models.

### DIFF
--- a/lib/foundation_rails_helper/form_builder.rb
+++ b/lib/foundation_rails_helper/form_builder.rb
@@ -74,7 +74,7 @@ module FoundationRailsHelper
 
   private
     def has_error?(attribute)
-      object.respond_to(:errors) && !object.errors[attribute].blank?
+      object.respond_to?(:errors) && !object.errors[attribute].blank?
     end
 
     def error_for(attribute, options = {})


### PR DESCRIPTION
Checks to see if it can respond to :errors or :human_attribute_name methods before calling them so you can still build forms that do not have an associated model.
