### PR TITLE
Made form builder more in line with Foundation styling

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ to `app/helpers/application_helper.rb`
 
 ### form_for
 
-Form_for wraps the standard rails form_for helper and adds a 'nice' class by default.
+Form_for wraps the standard rails form_for helper and adds a 'nice' and 'custom' class by default.
 
 ```erb
 <%= form_for @user do |f| %>
@@ -83,7 +83,7 @@ Form_for wraps the standard rails form_for helper and adds a 'nice' class by def
 generates:
 
 ```html
-<form accept-charset="UTF-8" action="/users" class="nice" id="new_user" method="post">
+<form accept-charset="UTF-8" action="/users" class="nice custom" id="new_user" method="post">
   ...
 ```
 
@@ -147,7 +147,7 @@ an additional span element will be added after the input element:
 
 ### Submit Button
 
-The 'submit' helper wraps the rails helper and sets the class attribute to "small radius success button" by default.
+The 'submit' helper wraps the rails helper and sets the class attribute to "small radius button" by default.
 
 ```ruby
 f.submit
@@ -156,7 +156,7 @@ f.submit
 generates:
 
 ```html
-<input class="small radius success button" name="commit" type="submit" value="Create User">
+<input class="small radius button" name="commit" type="submit" value="Create User">
 ```
 
 Specify the class option to override the default classes.

--- a/lib/foundation_rails_helper/action_view_extension.rb
+++ b/lib/foundation_rails_helper/action_view_extension.rb
@@ -4,7 +4,7 @@ module ActionView
       def form_for_with_foundation(record, options = {}, &block)
         options[:builder] ||= FoundationRailsHelper::FormBuilder
         options[:html] ||= {}
-        options[:html][:class] ||= 'nice'
+        options[:html][:class] ||= 'nice custom'
         form_for_without_foundation(record, options, &block)
       end
 

--- a/lib/foundation_rails_helper/form_builder.rb
+++ b/lib/foundation_rails_helper/form_builder.rb
@@ -68,7 +68,7 @@ module FoundationRailsHelper
     end
 
     def submit(value=nil, options={})
-      options[:class] ||= "small radius success button"
+      options[:class] ||= "small radius button"
       super(value, options)
     end
 

--- a/lib/foundation_rails_helper/form_builder.rb
+++ b/lib/foundation_rails_helper/form_builder.rb
@@ -14,7 +14,7 @@ module FoundationRailsHelper
     end
 
     def check_box(attribute, options = {}, checked_value = "1", unchecked_value = "0")
-      custom_label(attribute, options[:label], options[:label_options]) do
+      custom_label(attribute, ' ' + options[:label].to_s, options[:label_options]) do
         options.delete(:label)
         options.delete(:label_options)
         super(attribute, options, checked_value, unchecked_value)

--- a/lib/foundation_rails_helper/form_builder.rb
+++ b/lib/foundation_rails_helper/form_builder.rb
@@ -14,7 +14,7 @@ module FoundationRailsHelper
     end
 
     def check_box(attribute, options = {}, checked_value = "1", unchecked_value = "0")
-      custom_label(attribute, ' ' + options[:label].to_s, options[:label_options]) do
+      custom_label(attribute, options[:label], options[:label_options]) do
         options.delete(:label)
         options.delete(:label_options)
         super(attribute, options, checked_value, unchecked_value)


### PR DESCRIPTION
Removed the `success` class from the submit button because it conflicted with Foundation button stylings.
Added the `custom` class to the `form_for` helper to properly display the Foundation checkboxes and radio buttons.

Used with Foundation 4.3.2