### PR TITLE
Added an option for html_safe to be applied to the error messages.

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,8 @@ generates:
 
 The class attribute of the 'small' element will mirror the class attribute of the 'input' element.
 
+If the `html_safe_errors: true` option is specified on a field, then any HTML you may have embedded in a custom error string will be displayed with the html_safe option.
+
 ## TODO
 
 * Handle more UI components

--- a/lib/foundation_rails_helper/form_builder.rb
+++ b/lib/foundation_rails_helper/form_builder.rb
@@ -80,7 +80,11 @@ module FoundationRailsHelper
     def error_for(attribute, options = {})
       class_name = "error"
       class_name += " #{options[:class]}" if options[:class]
-      content_tag(:small, object.errors[attribute].join(', '), :class => class_name) if has_error?(attribute)
+      if has_error?(attribute)
+        error_messages = object.errors[attribute].join(', ')
+        error_messages = error_messages.html_safe if options[:html_safe_errors]
+        content_tag(:small, error_messages, :class => class_name)
+      end
     end
 
     def custom_label(attribute, text, options, &block)

--- a/spec/foundation_rails_helper/form_builder_spec.rb
+++ b/spec/foundation_rails_helper/form_builder_spec.rb
@@ -203,5 +203,19 @@ describe "FoundationRailsHelper::FormHelper" do
         node.should have_css('small.error', :text => "required")
       end
     end
+    it "should display HTML errors when the option is specified" do
+      form_for(@author) do |builder|
+        @author.stub!(:errors).and_return({:login => ['required <a href="link_target">link</a>']})
+        node = Capybara.string builder.text_field(:login, html_safe_errors: true)
+        node.should have_link('link', href: 'link_target')
+      end
+    end
+    it "should not display HTML errors when the option is not specified" do
+      form_for(@author) do |builder|
+        @author.stub!(:errors).and_return({:login => ['required <a href="link_target">link</a>']})
+        node = Capybara.string builder.text_field(:login)
+        node.should_not have_link('link', href: 'link')
+      end
+    end
   end
 end


### PR DESCRIPTION
I added this option because I have a use case where I have added HTML to a custom error message so that it contains a link.
