### PR TITLE
Fix problems with namespaced models and radio buttons

### DIFF
--- a/lib/foundation_rails_helper/form_builder.rb
+++ b/lib/foundation_rails_helper/form_builder.rb
@@ -22,7 +22,7 @@ module FoundationRailsHelper
     end
 
     def radio_button(attribute, tag_value, options = {})
-      options[:for] ||= "#{object.class.to_s.downcase}_#{attribute}_#{tag_value}"
+      options[:for] ||= "#{@object_name}_#{attribute}_#{tag_value}"
       c = super(attribute, tag_value, options)
       l = label(attribute, options.delete(:text), options)
       l.gsub(/(for=\"\w*\"\>)/, "\\1#{c} ").html_safe


### PR DESCRIPTION
Current master with this code:

```
<%= form_for Admin::User.new do |f| %>
  <%= f.radio_button active, 'true' %>
  <%= f.radio_button active, 'false' %>
<% end %>
```

will produce:

```
<label for="admin::user_active_true">True<label> 
<label for="admin::user_active_false">False</label> 
```

This is caused by the object name being in a namespace (the Admin:: part). This problem is fixed by using the object name derived by Rails itself, which is exactly what this pull_request does.
