### PR TITLE
added option to form_for that disables automatic creation of labels

### DIFF
--- a/lib/foundation_rails_helper/action_view_extension.rb
+++ b/lib/foundation_rails_helper/action_view_extension.rb
@@ -1,17 +1,18 @@
 module ActionView
   module Helpers
     module FormHelper
-      def form_for_with_foundation(record, options = {}, &block)
+      def form_for_with_foundation(record, options = {auto_labels: true}, &block)
         options[:builder] ||= FoundationRailsHelper::FormBuilder
         options[:html] ||= {}
         options[:html][:class] ||= 'nice'
         form_for_without_foundation(record, options, &block)
       end
 
-      def fields_for_with_foundation(record_name, record_object = nil, options = {}, &block)
+      def fields_for_with_foundation(record_name, record_object = nil, options = {auto_labels: true}, &block)
         options[:builder] ||= FoundationRailsHelper::FormBuilder
         options[:html] ||= {}
         options[:html][:class] ||= 'nice'
+        options[:html][:attached_labels] = options[:attached_labels]
         fields_for_without_foundation(record_name, record_object, options, &block)
       end
 

--- a/lib/foundation_rails_helper/form_builder.rb
+++ b/lib/foundation_rails_helper/form_builder.rb
@@ -13,6 +13,13 @@ module FoundationRailsHelper
       end
     end
 
+    def label(attribute, text = nil, options = {})
+      options[:class] ||= ""
+      options[:class] += " error" if has_error?(attribute)
+      super(attribute, text, options)
+    end
+
+
     def check_box(attribute, options = {}, checked_value = "1", unchecked_value = "0")
       custom_label(attribute, options[:label], options[:label_options]) do
         options.delete(:label)
@@ -88,16 +95,15 @@ module FoundationRailsHelper
     end
 
     def custom_label(attribute, text, options, &block)
-      if text == false
-        text = ""
-      elsif text.nil?
+      return block_given? ? block.call.html_safe : "".html_safe if text == false
+      if text.nil? || text == true
         text = if object.class.respond_to?(:human_attribute_name)
           object.class.human_attribute_name(attribute)
         else
           attribute.to_s.humanize
         end
       end
-      text = block.call.html_safe + text if block_given?
+      text = block.call.html_safe + " #{text}" if block_given?
       options ||= {}
       options[:class] ||= ""
       options[:class] += " error" if has_error?(attribute)
@@ -113,7 +119,7 @@ module FoundationRailsHelper
 
     def field(attribute, options, &block)
       html = ''.html_safe
-      html = custom_label(attribute, options[:label], options[:label_options]) if false != options[:label]
+      html = custom_label(attribute, options[:label], options[:label_options]) if @options[:auto_labels] || options[:label]
       options[:class] ||= "medium"
       options[:class] = "#{options[:class]} input-text"
       options[:class] += " error" if has_error?(attribute)

--- a/spec/foundation_rails_helper/form_builder_spec.rb
+++ b/spec/foundation_rails_helper/form_builder_spec.rb
@@ -116,9 +116,9 @@ describe "FoundationRailsHelper::FormHelper" do
     it "should generate check_box input without a label" do
       form_for(@author) do |builder|
         node = Capybara.string builder.check_box(:active, :label => false)
-        node.should have_css('label[for="author_active"] input[type="hidden"][name="author[active]"][value="0"]')
-        node.should have_css('label[for="author_active"] input[type="checkbox"][name="author[active]"]')
-        node.should have_css('label[for="author_active"]', :text => "")
+        node.should have_css('input[type="hidden"][name="author[active]"][value="0"]')
+        node.should have_css('input[type="checkbox"][name="author[active]"]')
+        node.should_not have_css('label[for="author_active"]')
       end
     end
 
@@ -217,5 +217,18 @@ describe "FoundationRailsHelper::FormHelper" do
         node.should_not have_link('link', href: 'link')
       end
     end
+
+    it "should not display labels unless specified in the builder method" do
+      form_for(@author, auto_labels: false) do |builder|
+        node = Capybara.string builder.text_field(:login) +
+          builder.check_box(:active, label: true) +
+          builder.text_field(:description, label: 'Tell me about you')
+
+        node.should_not have_css('label[for="author_login"]')
+        node.should have_css('label[for="author_active"]', text: 'Active')
+        node.should have_css('label[for="author_description"]', text: 'Tell me about you')
+      end
+    end
+    
   end
 end


### PR DESCRIPTION
Title is kinda self-explanatory, default behaviour hasn't changed.

Here's an example of how it works:

``` erb
<%= form_for @article, auto_labels: false do |f| %>
  <%= f.text_field :title %> # no label
  <%= f.datetime_select :publish_date, label: 'Will be published on' %> # labelled 'Will be published on'
  <%= f.check_box :important, label: true %> # labelled 'Important'
<% end %>
```
