### PR TITLE
Fix timezone_select method to provide better support for priorities

### DIFF
--- a/lib/foundation_rails_helper/form_builder.rb
+++ b/lib/foundation_rails_helper/form_builder.rb
@@ -46,9 +46,9 @@ module FoundationRailsHelper
       end
     end
 
-    def time_zone_select(attribute, options = {})
+    def time_zone_select(attribute, priorities = nil, options = {}, html_options = {})
       field attribute, options do |options|
-        super(attribute, {}, options.merge(:autocomplete => :off))
+        super(attribute, priorities, options, html_options.merge(:autocomplete => :off))
       end
     end
 

--- a/spec/foundation_rails_helper/form_builder_spec.rb
+++ b/spec/foundation_rails_helper/form_builder_spec.rb
@@ -187,6 +187,15 @@ describe "FoundationRailsHelper::FormHelper" do
         %w(1).each   {|i| node.should_not have_css("select.medium.input-text[name='author[birthdate(#{i}i)]']") }
       end
     end
+
+    it "should generate time_zone_select input" do
+      form_for(@author) do |builder|
+        node = Capybara.string builder.label(:time_zone) + builder.time_zone_select(:time_zone)
+        node.should have_css('label[for="author_time_zone"]', :text => "Time zone")
+        node.should have_css('select[name="author[time_zone]"]')
+        node.should have_css('select[name="author[time_zone]"] option[value="Perth"]', :text => "(GMT+08:00) Perth")
+      end
+    end
   end
 
   describe "errors generator" do

--- a/spec/support/mock_rails.rb
+++ b/spec/support/mock_rails.rb
@@ -85,6 +85,7 @@ module FoundationRailsSpecHelper
     @author.stub!(:errors).and_return(mock('errors', :[] => nil))
     @author.stub!(:to_key).and_return(nil)
     @author.stub!(:persisted?).and_return(nil)
+    @author.stub!(:time_zone).and_return("Perth")
 
     ::Author.stub!(:scoped).and_return(::Author)
     ::Author.stub!(:find).and_return([@author])


### PR DESCRIPTION
Fix timezone_select method to provide better support for priorities

time_zone_select() would raise TypeError as written saying 'no implicit
conversion of Hash into Array'. This is because the 2nd parameter to
FormOptionsHelper#time_zone_select is supposed to be an Array. And
FoundationRailsHelper::FormBuilder#time_zone_select() was passing in a Hash.

The array being passed in is to be a list of priority time zones that show up at
the top of the select list. This option is now supported.
