### PR TITLE
foundation_rails_helper.gemspec: updated tzinfo version for Rails 4.1.rc1 compatibility.

### DIFF
--- a/foundation_rails_helper.gemspec
+++ b/foundation_rails_helper.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'railties', '>= 3.0'
   gem.add_dependency "actionpack", '>= 3.0'
   gem.add_dependency "activemodel", '>= 3.0'
-  gem.add_dependency "tzinfo", "~> 0.3.37"
+  gem.add_dependency "tzinfo", "~> 1.1.0"
   gem.add_development_dependency "rspec-rails", '2.8.1'
   gem.add_development_dependency "capybara"
 end


### PR DESCRIPTION
without this i get the following error when trying to install current master in my Gemfile in a Rails 4.1.rc1 project:

Gemfile:
`gem 'foundation_rails_helper', github: 'sgruhier/foundation_rails_helper'`

`bundle update foundation_rails_helper` returns:

```
Bundler could not find compatible versions for gem "tzinfo":
In Gemfile:
foundation_rails_helper (>= 0) ruby depends on
tzinfo (~> 0.3.37) ruby

rails (~> 4.1.0.rc1) ruby depends on
  tzinfo (1.1.0)
```
