### PR TITLE
Create radio buttons in the presence of extra attributes

### DIFF
--- a/lib/foundation_rails_helper/form_builder.rb
+++ b/lib/foundation_rails_helper/form_builder.rb
@@ -34,7 +34,8 @@ module FoundationRailsHelper
       options[:for] ||= "#{@object_name}_#{attribute}_#{tag_value}"
       c = super(attribute, tag_value, options)
       l = label(attribute, options.delete(:text), options)
-      l.gsub(/(for=\"\w*\"\>)/, "\\1#{c} ").html_safe
+      # insert radio button inside label
+      l.gsub(/(<label.*?>)/, "\\1#{c} ").html_safe
     end
 
     def password_field(attribute, options = {})

--- a/spec/foundation_rails_helper/form_builder_spec.rb
+++ b/spec/foundation_rails_helper/form_builder_spec.rb
@@ -159,6 +159,14 @@ describe "FoundationRailsHelper::FormHelper" do
       end
     end
 
+    it 'should generate a radio button in the presence of extra attributes' do
+      form_for(@author) do |builder|
+        node = Capybara.string builder.radio_button(:active, true, text: "Functioning", required: true)
+        node.should have_css('input[type="radio"][name="author[active]"]')
+        node.should have_css('label[for="author_active_true"]', text: "Functioning")
+      end
+    end
+
     it "should generate date_select input" do
       form_for(@author) do |builder|
         node = Capybara.string builder.label(:birthdate) + builder.date_select(:birthdate)


### PR DESCRIPTION
In the current code base, if you add an extra attribute to a radio button with code like:

```ruby
<%= f.radio_button :do_thing, true, text: "Yes", required: true %>
```

foundation rails helper will generate a radio button and a label; it will then, however, throw the radio button away.

The regular expression intended to insert the radio button inside the label tag assumes that the `for` attribute on the label is the last one, and is followed immediately by the closing `>`. In the presence of extra attributes, the extra attributes come last and break this assumption.

My fix replaces the broken regex with a non-greedy search of the entire label tag, which makes it insensitive to extra attributes.