### PR TITLE
[Rails 4.1] Record Identifier: ActionController -> ActionView

### DIFF
--- a/spec/support/mock_rails.rb
+++ b/spec/support/mock_rails.rb
@@ -11,7 +11,7 @@ require 'active_support/core_ext'
 module FoundationRailsSpecHelper
   include ActionPack
   include ActionView::Context if defined?(ActionView::Context)
-  include ActionController::RecordIdentifier
+  include ActionView::RecordIdentifier
   include ActionView::Helpers::FormHelper
   include ActionView::Helpers::FormTagHelper
   include ActionView::Helpers::FormOptionsHelper


### PR DESCRIPTION
There is an `include` in _mock_rails.rb_ that seems to be not compatible with Rails 4.1+.  RecordIdentifier (`dom_class`) has moved from ActionController to ActionView.  Ref: http://api.rubyonrails.org/classes/ActionView/RecordIdentifier.html.  You'll have to decide if you want to to do a Rails 4.1 branch or something else.
