### PR TITLE
Correctly apply the error class to all of the different types of input

### DIFF
--- a/lib/foundation_rails_helper/form_builder.rb
+++ b/lib/foundation_rails_helper/form_builder.rb
@@ -44,19 +44,19 @@ module FoundationRailsHelper
     end
 
     def datetime_select(attribute, options = {}, html_options = {})
-      field attribute, html_options do |html_options|
+      field attribute, options, html_options do |html_options|
         super(attribute, options, html_options.merge(:autocomplete => :off))
       end
     end
 
     def date_select(attribute, options = {}, html_options = {})
-      field attribute, html_options do |html_options|
+      field attribute, options, html_options do |html_options|
         super(attribute, options, html_options.merge(:autocomplete => :off))
       end
     end
 
     def time_zone_select(attribute, priorities = nil, options = {}, html_options = {})
-      field attribute, options do |options|
+      field attribute, options, html_options do |html_options|
         super(attribute, priorities, options, html_options.merge(:autocomplete => :off))
       end
     end
@@ -69,14 +69,14 @@ module FoundationRailsHelper
     end
 
     def collection_select(attribute, collection, value_method, text_method, options = {}, html_options = {})
-      field attribute, options do |options|
+      field attribute, options, html_options do |html_options|
         html_options[:autocomplete] ||= :off
         super(attribute, collection, value_method, text_method, options, html_options)
       end
     end
 
     def grouped_collection_select(attribute, collection, group_method, group_label_method, option_key_method, option_value_method, options = {}, html_options = {})
-      field attribute, options do |options|
+      field attribute, options, html_options do |html_options|
         html_options[:autocomplete] ||= :off
         super(attribute, collection, group_method, group_label_method, option_key_method, option_value_method, options, html_options)
       end
@@ -138,7 +138,7 @@ module FoundationRailsHelper
       html = custom_label(attribute, options[:label], options[:label_options]) if @options[:auto_labels] || options[:label]
       class_options = html_options || options
       class_options[:class] ||= "medium"
-      class_options[:class] = "#{options[:class]} input-text"
+      class_options[:class] = "#{class_options[:class]} input-text"
       class_options[:class] += " error" if has_error?(attribute)
       options.delete(:label)
       options.delete(:label_options)

--- a/spec/foundation_rails_helper/form_builder_spec.rb
+++ b/spec/foundation_rails_helper/form_builder_spec.rb
@@ -335,20 +335,65 @@ describe "FoundationRailsHelper::FormHelper" do
         node.should have_css('small.error', :text => "required")
       end
     end
-    it "should display errors on input" do
-      form_for(@author) do |builder|
-        @author.stub!(:errors).and_return({:login => ['required']})
-        node = Capybara.string builder.text_field(:login)
-        node.should have_css('input.error[name="author[login]"]')
+    %w(file_field email_field text_field telephone_field phone_field
+       url_field number_field date_field datetime_field datetime_local_field
+       month_field week_field time_field range_field search_field color_field
+
+       password_field
+       ).each do |field|
+      it "should display errors on #{field} inputs" do
+        form_for(@author) do |builder|
+          @author.stub!(:errors).and_return({:description => ['required']})
+          node = Capybara.string builder.public_send(field, :description)
+          node.should have_css('input.error[name="author[description]"]')
+        end
       end
     end
-    it "should display errors on select" do
+    it "should display errors on text_area inputs" do
+      form_for(@author) do |builder|
+        @author.stub!(:errors).and_return({:description => ['required']})
+        node = Capybara.string builder.text_area(:description)
+        node.should have_css('textarea.error[name="author[description]"]')
+      end
+    end
+    it "should display errors on select inputs" do
       form_for(@author) do |builder|
         @author.stub!(:errors).and_return({:favorite_book => ['required']})
         node = Capybara.string builder.select(:favorite_book, [["Choice #1", :a], ["Choice #2", :b]])
         node.should have_css('select.error[name="author[favorite_book]"]')
       end
     end
+    it "should display errors on date_select inputs" do
+      form_for(@author) do |builder|
+        @author.stub!(:errors).and_return({:birthdate => ['required']})
+        node = Capybara.string builder.date_select(:birthdate)
+        %w(1 2 3).each {|i| node.should have_css("select.error[name='author[birthdate(#{i}i)]']") }
+      end
+    end
+    it "should display errors on datetime_select inputs" do
+      form_for(@author) do |builder|
+        @author.stub!(:errors).and_return({:birthdate => ['required']})
+        node = Capybara.string builder.datetime_select(:birthdate)
+        %w(1 2 3 4 5).each {|i| node.should have_css("select.error[name='author[birthdate(#{i}i)]']") }
+      end
+    end
+    it "should display errors on time_zone_select inputs"  do
+      form_for(@author) do |builder|
+        @author.stub!(:errors).and_return({:time_zone => ['required']})
+        node = Capybara.string builder.time_zone_select(:time_zone)
+        node.should have_css('select.error[name="author[time_zone]"]')
+      end
+    end
+
+    it "should display errors on collection_select inputs" do
+      pending("Not sure how to test this")
+    end
+    it "should display errors on grouped_collection_select inputs" do
+      pending("Not sure how to test this")
+    end
+
+    # N.B. check_box and radio_button inputs don't have the error class applied
+
     it "should display HTML errors when the option is specified" do
       form_for(@author) do |builder|
         @author.stub!(:errors).and_return({:login => ['required <a href="link_target">link</a>']})


### PR DESCRIPTION
As discussed in #61, the `error` class is not getting correctly applied to all inputs, because some inputs (e.g. text_field) pass the html class option in the `options` hash, while others (e.g. select) pass it in a seperate `html_options` hash.

This pull request hopefully addresses this and adds tests.
