### PR TITLE
Bumping the tzinfo version to 1.2.2

### DIFF
--- a/foundation_rails_helper.gemspec
+++ b/foundation_rails_helper.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "actionpack", '~> 4.1.1'
   gem.add_dependency "activemodel", '~> 4.1.1'
   gem.add_dependency "activesupport", '~> 4.1.1'
-  gem.add_dependency "tzinfo", "~> 1.1.0"
+  gem.add_dependency "tzinfo", "~> 1.2.2"
 
   gem.add_development_dependency "rspec-rails", '2.8.1'
   gem.add_development_dependency "capybara"


### PR DESCRIPTION
This is the ruby timezone library. I've ran the tests and everything passes.

In the version of Rails I'm using (4.1.5), activesupport has `tzinfo (~> 1.1)`
Since this gem is designed to be used with Rails I'm not sure it makes sense to have a more prescriptive dependency, but I'm happy to be corrected on that.
