### PR TITLE
label helper should not add empty class attribute

### DIFF
--- a/lib/foundation_rails_helper/form_builder.rb
+++ b/lib/foundation_rails_helper/form_builder.rb
@@ -16,8 +16,10 @@ module FoundationRailsHelper
     end
 
     def label(attribute, text = nil, options = {})
-      options[:class] ||= ""
-      options[:class] += " error" if has_error?(attribute)
+      if has_error?(attribute)
+        options[:class] ||= ""
+        options[:class] += " error"
+      end
       super(attribute, (text || "").html_safe, options)
     end
 
@@ -124,8 +126,6 @@ module FoundationRailsHelper
       end
       text = block.call.html_safe + " #{text}" if block_given?
       options ||= {}
-      options[:class] ||= ""
-      options[:class] += " error" if has_error?(attribute)
       label(attribute, text, options)
     end
 

--- a/spec/foundation_rails_helper/form_builder_spec.rb
+++ b/spec/foundation_rails_helper/form_builder_spec.rb
@@ -34,6 +34,26 @@ describe "FoundationRailsHelper::FormHelper" do
     end
   end
 
+  describe "label" do
+    context "when there aren't any errors and no class option is passed" do
+      it "should not have a class attribute" do
+        form_for(@author) do |builder|
+          node = Capybara.string builder.text_field(:login)
+          expect(node).to have_css('label:not([class=""])')
+        end        
+      end
+    end
+
+    it "should not have error class multiple times" do
+      form_for(@author) do |builder|
+        allow(@author).to receive(:errors).and_return({:login => ['required']})
+        node = Capybara.string builder.text_field(:login)
+        error_class = node.find('label')['class'].split(/\s+/).keep_if { |v| v == 'error' }
+        expect(error_class.size).to eq 1
+      end  
+    end
+  end
+
   describe "input generators" do
     it "should generate text_field input" do
       form_for(@author) do |builder|


### PR DESCRIPTION
If we don't have a class nor errors, the class attribute should not be added to the element.