### PR TITLE
Allow blacklisting of flash keys which are only used for state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## NEXT VERSION
+* Flash Helper: a list of keys to be ignored can be specified - e.g. keys which are only used internally to pass data, not user-viewable messages(fix for #98)
+
 ## Version 1.0.0
 
 * Released Feb 03rd 2015

--- a/README.md
+++ b/README.md
@@ -171,16 +171,25 @@ The class attribute of the 'small' element will mirror the class attribute of th
 If the `html_safe_errors: true` option is specified on a field, then any HTML you may have embedded in a custom error string will be displayed with the html_safe option.
 
 ## Configuration
-Add an initializer file to your Rails app: *config/initializers/foundation_rails_helper.rb*.  See below for current options.
+Add an initializer file to your Rails app: *config/initializers/foundation_rails_helper.rb*
+containing the following block:
 
-### Submit Button Class
-To use a different class for the [submit button](https://github.com/sgruhier/foundation_rails_helper#submit-button) used in `form_for`, add a config named **button_class**.  Please note, the button class can still be overridden by an options hash.
 ```ruby
 FoundationRailsHelper.configure do |config|
-  # Default: 'small radius success button'
-  config.button_class = 'large secondary button'
+  # your options here
 end
 ```
+
+Currently supported options:
+
+### Submit Button Class
+To use a different class for the [submit button](https://github.com/sgruhier/foundation_rails_helper#submit-button) used in `form_for`, add a config named **button_class**:
+```ruby
+# Default: 'small radius success button'
+config.button_class = 'large secondary button'
+```
+
+Please note, the button class can still be overridden by an options hash.
 
 ### Ignored Flash Keys
 The flash helper assumes all flash entries are user-viewable messages.
@@ -188,10 +197,8 @@ To exclude flash entries which are used for storing state
 (e.g. [Devise's `:timedout` flash](https://github.com/plataformatec/devise/issues/1777))
 you can specify a blacklist of keys to ignore with the **ignored_flash_keys** config option:
 ```ruby
-FoundationRailsHelper.configure do |config|
-  # Default: []
-  config.ignored_flash_keys = [:timedout]
-end
+# Default: []
+config.ignored_flash_keys = [:timedout]
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -182,6 +182,18 @@ FoundationRailsHelper.configure do |config|
 end
 ```
 
+### Ignored Flash Keys
+The flash helper assumes all flash entries are user-viewable messages.
+To exclude flash entries which are used for storing state
+(e.g. [Devise's `:timedout` flash](https://github.com/plataformatec/devise/issues/1777))
+you can specify a blacklist of keys to ignore with the **ignored_flash_keys** config option:
+```ruby
+FoundationRailsHelper.configure do |config|
+  # Default: []
+  config.ignored_flash_keys = [:timedout]
+end
+```
+
 ## Contributing
 
 See the [CONTRIBUTING](CONTRIBUTING.md) file.

--- a/lib/foundation_rails_helper/configuration.rb
+++ b/lib/foundation_rails_helper/configuration.rb
@@ -17,9 +17,11 @@ module FoundationRailsHelper
 
   class Configuration
     attr_accessor :button_class
+    attr_accessor :ignored_flash_keys
 
     def initialize
       @button_class = 'small radius success button'
+      @ignored_flash_keys = []
     end
   end
 end

--- a/lib/foundation_rails_helper/flash_helper.rb
+++ b/lib/foundation_rails_helper/flash_helper.rb
@@ -17,12 +17,28 @@ module FoundationRailsHelper
     }
     def display_flash_messages(key_matching = {})
       key_matching = DEFAULT_KEY_MATCHING.merge(key_matching)
+      key_matching.default = :standard
 
-      flash.inject "" do |message, (key, value)|
-        message += content_tag :div, :data => { :alert => "" }, :class => "alert-box #{key_matching[key.to_sym] || :standard}" do
-          (value + link_to("&times;".html_safe, "#", :class => :close)).html_safe
+      capture do
+        flash.each do |key, value|
+          alert_class = key_matching[key.to_sym]
+          concat alert_box(value, alert_class)
         end
-      end.html_safe
+      end
     end
+
+  private
+
+    def alert_box(value, alert_class)
+      content_tag :div, :data => { :alert => "" }, :class => "alert-box #{alert_class}" do
+        concat value
+        concat close_link
+      end
+    end
+
+    def close_link
+      link_to("&times;".html_safe, "#", :class => :close)
+    end
+
   end
 end

--- a/lib/foundation_rails_helper/flash_helper.rb
+++ b/lib/foundation_rails_helper/flash_helper.rb
@@ -21,6 +21,7 @@ module FoundationRailsHelper
 
       capture do
         flash.each do |key, value|
+          next if FoundationRailsHelper.configuration.ignored_flash_keys.include? key.to_sym
           alert_class = key_matching[key.to_sym]
           concat alert_box(value, alert_class)
         end

--- a/spec/foundation_rails_helper/configuration_spec.rb
+++ b/spec/foundation_rails_helper/configuration_spec.rb
@@ -3,7 +3,6 @@ require 'spec_helper'
 describe FoundationRailsHelper do
 
   describe FoundationRailsHelper::Configuration do
-    # describe "accessors" do
     describe "#button_class" do
       it "default value is 'small radius success button'" do
         config = FoundationRailsHelper::Configuration.new

--- a/spec/foundation_rails_helper/configuration_spec.rb
+++ b/spec/foundation_rails_helper/configuration_spec.rb
@@ -3,6 +3,7 @@ require 'spec_helper'
 describe FoundationRailsHelper do
 
   describe FoundationRailsHelper::Configuration do
+    # describe "accessors" do
     describe "#button_class" do
       it "default value is 'small radius success button'" do
         config = FoundationRailsHelper::Configuration.new
@@ -18,18 +19,42 @@ describe FoundationRailsHelper do
       end
     end
 
+    describe "#ignored_flash_keys" do
+      it "defaults to empty" do
+        config = FoundationRailsHelper::Configuration.new
+        expect(config.ignored_flash_keys).to eq([])
+      end
+    end
+
+    describe "#ignored_flash_keys=" do
+      it "can set the value" do
+        config = FoundationRailsHelper::Configuration.new
+        config.ignored_flash_keys = [:foo]
+        expect(config.ignored_flash_keys).to eq([:foo])
+      end
+    end
+
     describe ".reset" do
-      before :each do
+      it "resets the configured button class" do
         FoundationRailsHelper.configure do |config|
           config.button_class = 'new-class'
         end
-      end
 
-      it "resets the configuration" do
         FoundationRailsHelper.reset
 
         config = FoundationRailsHelper.configuration
         expect(config.button_class).to eq('small radius success button')
+      end
+
+      it "resets the configured ignored flash keys" do
+        FoundationRailsHelper.configure do |config|
+          config.ignored_flash_keys = [:new_key]
+        end
+
+        FoundationRailsHelper.reset
+
+        config = FoundationRailsHelper.configuration
+        expect(config.ignored_flash_keys).to eq([])
       end
     end
   end

--- a/spec/foundation_rails_helper/flash_helper_spec.rb
+++ b/spec/foundation_rails_helper/flash_helper_spec.rb
@@ -6,33 +6,43 @@ describe FoundationRailsHelper::FlashHelper do
   include ActionView::Context if defined?(ActionView::Context)
   include ActionView::Helpers::UrlHelper
   include ActionView::Helpers::TagHelper
+  include ActionView::Helpers::TextHelper
   include FoundationRailsHelper::FlashHelper
 
   FoundationRailsHelper::FlashHelper::DEFAULT_KEY_MATCHING.each do |message_type, foundation_type|
     it "displays flash message with #{foundation_type} class for #{message_type} message" do
       allow(self).to receive(:flash).and_return({message_type => "Flash message"})
       node = Capybara.string display_flash_messages
-      expect(node).to have_css("div.alert-box.#{foundation_type}", :text => "Flash message")
-      expect(node).to have_css("div.alert-box a.close", :text => "×")
+      expect(node).
+        to  have_css("div.alert-box.#{foundation_type}", :text => "Flash message").
+        and have_css("div.alert-box a.close", :text => "×")
     end
+  end
+
+  it "displays multiple flash messages" do
+    allow(self).to receive(:flash).and_return({ success: "Yay it worked", error: "But this other thing failed" })
+    node = Capybara.string display_flash_messages
+    expect(node).
+      to  have_css("div.alert-box.success", :text => "Yay it worked").
+      and have_css("div.alert-box.alert",   :text => "But this other thing failed")
   end
 
   it "displays flash message with overridden key matching" do
     allow(self).to receive(:flash).and_return({:notice => "Flash message"})
     node = Capybara.string display_flash_messages({:notice => :alert})
-    expect(node).to have_css("div.alert-box.alert")
+    expect(node).to have_css("div.alert-box.alert", :text => "Flash message")
   end
 
   it "displays flash message with custom key matching" do
     allow(self).to receive(:flash).and_return({:custom_type => "Flash message"})
     node = Capybara.string display_flash_messages({:custom_type => :custom_class})
-    expect(node).to have_css("div.alert-box.custom_class")
+    expect(node).to have_css("div.alert-box.custom_class", :text => "Flash message")
   end
 
   it "displays flash message with standard class if key doesn't match" do
     allow(self).to receive(:flash).and_return({:custom_type => "Flash message"})
     node = Capybara.string display_flash_messages
-    expect(node).to have_css("div.alert-box.standard")
+    expect(node).to have_css("div.alert-box.standard", :text => "Flash message")
   end
   
   it "shouldn't die when flash hash contains devise internal data" do

--- a/spec/foundation_rails_helper/flash_helper_spec.rb
+++ b/spec/foundation_rails_helper/flash_helper_spec.rb
@@ -20,7 +20,7 @@ describe FoundationRailsHelper::FlashHelper do
   end
 
   it "handles symbol keys" do
-    allow(self).to receive(:flash).and_return({ "success" => "Flash message" })
+    allow(self).to receive(:flash).and_return({ :success => "Flash message" })
     node = Capybara.string display_flash_messages
     expect(node).to have_css("div.alert-box.success", :text => "Flash message")
   end

--- a/spec/foundation_rails_helper/flash_helper_spec.rb
+++ b/spec/foundation_rails_helper/flash_helper_spec.rb
@@ -11,7 +11,7 @@ describe FoundationRailsHelper::FlashHelper do
 
   FoundationRailsHelper::FlashHelper::DEFAULT_KEY_MATCHING.each do |message_type, foundation_type|
     it "displays flash message with #{foundation_type} class for #{message_type} message" do
-      allow(self).to receive(:flash).and_return({message_type => "Flash message"})
+      allow(self).to receive(:flash).and_return({message_type.to_s => "Flash message"})
       node = Capybara.string display_flash_messages
       expect(node).
         to  have_css("div.alert-box.#{foundation_type}", :text => "Flash message").
@@ -19,8 +19,20 @@ describe FoundationRailsHelper::FlashHelper do
     end
   end
 
+  it "handles symbol keys" do
+    allow(self).to receive(:flash).and_return({ "success" => "Flash message" })
+    node = Capybara.string display_flash_messages
+    expect(node).to have_css("div.alert-box.success", :text => "Flash message")
+  end
+
+  it "handles string keys" do
+    allow(self).to receive(:flash).and_return({ "success" => "Flash message" })
+    node = Capybara.string display_flash_messages
+    expect(node).to have_css("div.alert-box.success", :text => "Flash message")
+  end
+
   it "displays multiple flash messages" do
-    allow(self).to receive(:flash).and_return({ success: "Yay it worked", error: "But this other thing failed" })
+    allow(self).to receive(:flash).and_return({ "success" => "Yay it worked", "error" => "But this other thing failed" })
     node = Capybara.string display_flash_messages
     expect(node).
       to  have_css("div.alert-box.success", :text => "Yay it worked").
@@ -28,19 +40,19 @@ describe FoundationRailsHelper::FlashHelper do
   end
 
   it "displays flash message with overridden key matching" do
-    allow(self).to receive(:flash).and_return({:notice => "Flash message"})
+    allow(self).to receive(:flash).and_return({ "notice" => "Flash message" })
     node = Capybara.string display_flash_messages({:notice => :alert})
     expect(node).to have_css("div.alert-box.alert", :text => "Flash message")
   end
 
   it "displays flash message with custom key matching" do
-    allow(self).to receive(:flash).and_return({:custom_type => "Flash message"})
+    allow(self).to receive(:flash).and_return({ "custom_type" => "Flash message" })
     node = Capybara.string display_flash_messages({:custom_type => :custom_class})
     expect(node).to have_css("div.alert-box.custom_class", :text => "Flash message")
   end
 
   it "displays flash message with standard class if key doesn't match" do
-    allow(self).to receive(:flash).and_return({:custom_type => "Flash message"})
+    allow(self).to receive(:flash).and_return({ "custom_type" => "Flash message" })
     node = Capybara.string display_flash_messages
     expect(node).to have_css("div.alert-box.standard", :text => "Flash message")
   end


### PR DESCRIPTION
This PR adds a config option to specify a blacklist of flash keys to be ignored (fixing #98) 

It also refactors the flash helper to make it more clear and robust