### PR TITLE
Don't output label="false" on radio_button

### DIFF
--- a/lib/foundation_rails_helper/form_builder.rb
+++ b/lib/foundation_rails_helper/form_builder.rb
@@ -36,8 +36,9 @@ module FoundationRailsHelper
     def radio_button(attribute, tag_value, options = {})
       options[:label_options] ||= {}
       label_options = options.delete(:label_options).merge!(value: tag_value)
-      unless options[:label] == false
-        l = label(attribute, options.delete(:label), label_options)
+      label_text = options.delete(:label)
+      unless label_text == false
+        l = label(attribute, label_text, label_options)
       end
       r = @template.radio_button(@object_name, attribute, tag_value,
                                  objectify_options(options))

--- a/spec/foundation_rails_helper/form_builder_spec.rb
+++ b/spec/foundation_rails_helper/form_builder_spec.rb
@@ -315,6 +315,7 @@ describe "FoundationRailsHelper::FormHelper" do
       form_for(@author) do |builder|
         node = Capybara.string builder.radio_button(:active, "ok", label: false)
         expect(node).to_not have_css('label[for="author_active_ok"]')
+        expect(node).to_not have_css('input[label="false"]')
         expect(node).to have_css('input[type="radio"][name="author[active]"]')
       end
     end


### PR DESCRIPTION
I noticed that setting label: false would generate label="false" as attribute on my radio buttons. This fixes it.