### PR TITLE
add mime-types as a dev dependency

### DIFF
--- a/foundation_rails_helper.gemspec
+++ b/foundation_rails_helper.gemspec
@@ -23,5 +23,6 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'tzinfo',        '~> 1.2', '>= 1.2.2'
 
   gem.add_development_dependency 'rspec-rails', '~> 3.1', '>= 3.1.0'
+  gem.add_development_dependency 'mime-types',  '~> 2'
   gem.add_development_dependency 'capybara',    '~> 2.4', '>= 2.4.3'
 end


### PR DESCRIPTION
fixes error when using ruby -v 1.9.3
mime-types 3+ is incompatible with 1.9.3
only an issue in development env as mime-types is
a capybara dependency only