### PR TITLE
Add rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,10 @@
+AllCops:
+  Include:
+    - Rakefile
+    - Gemfile
+    - '*.gemspec'
+  Exclude:
+    - 'vendor/**/*'
+
+Documentation:
+  Enabled: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
+language: ruby
 rvm:
   - 1.9.3
-  - 2.1.0
-  - 2.2.0
+  - 2.1.7
+  - 2.2.3
 sudo: false
+script:
+  - bundle exec rake
+  - bundle exec rubocop

--- a/foundation_rails_helper.gemspec
+++ b/foundation_rails_helper.gemspec
@@ -25,4 +25,5 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'rspec-rails', '~> 3.1', '>= 3.1.0'
   gem.add_development_dependency 'mime-types',  '~> 2'
   gem.add_development_dependency 'capybara',    '~> 2.4', '>= 2.4.3'
+  gem.add_development_dependency 'rubocop',     '~> 0.35'
 end

--- a/spec/.rubocop.yml
+++ b/spec/.rubocop.yml
@@ -1,0 +1,5 @@
+inherit_from:
+  - ../.rubocop.yml
+
+StringLiterals:
+  EnforcedStyle: double_quotes

--- a/spec/support/.rubocop.yml
+++ b/spec/support/.rubocop.yml
@@ -1,0 +1,2 @@
+inherit_from:
+  - ../../.rubocop.yml


### PR DESCRIPTION
Lately, I've been using the [rubocop](https://github.com/bbatsov/rubocop) linter, which follows the [Ruby Style Guidline](https://github.com/bbatsov/ruby-style-guide).  I feel it keeps my code consistent and easy to read.  I purpose we add rubocop configs (*.rubocop.yml*) to this gem and enforce code style for future additions.  Also, I've added a linting step to our Travis CI so checking style is less painful.  Of course, the settings we choose for the rubocop configs are open to debate.

Where I deviate a little from the norm is I like to use double quotes in my spec files, while single everywhere else.

I'm willing to go through the code and fix any errors.