### PR TITLE
Add "flash" class to callout

### DIFF
--- a/lib/foundation_rails_helper/flash_helper.rb
+++ b/lib/foundation_rails_helper/flash_helper.rb
@@ -36,7 +36,7 @@ module FoundationRailsHelper
     def alert_box(value, alert_class)
       content_tag(
         :div,
-        :class => "callout #{alert_class}",
+        :class => "flash callout #{alert_class}",
         :data => { closable: '' }
       ) do
         concat value

--- a/spec/foundation_rails_helper/flash_helper_spec.rb
+++ b/spec/foundation_rails_helper/flash_helper_spec.rb
@@ -15,7 +15,7 @@ describe FoundationRailsHelper::FlashHelper do
       allow(self).to receive(:flash).and_return({message_type.to_s => "Flash message"})
       node = Capybara.string display_flash_messages
       expect(node).
-        to  have_css("div.callout.#{foundation_type}", :text => "Flash message").
+        to  have_css("div.flash.callout.#{foundation_type}", :text => "Flash message").
         and have_css("[data-close]", :text => "×")
     end
   end


### PR DESCRIPTION
It makes it so the callout added by flash messages is easier to select with CSS as opposed to callouts already on the page.