### PR TITLE
Lock capybara at 2.6

### DIFF
--- a/foundation_rails_helper.gemspec
+++ b/foundation_rails_helper.gemspec
@@ -24,5 +24,5 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency 'rspec-rails', '>= 3.1'
   gem.add_development_dependency 'mime-types',  '~> 2'
-  gem.add_development_dependency 'capybara',    '~> 2.4', '>= 2.4.3'
+  gem.add_development_dependency 'capybara',    '~> 2.6.0'
 end


### PR DESCRIPTION
Version 2.7.1 causes check_box tests to break.