### PR TITLE
(chore): upgrade capybara

### DIFF
--- a/foundation_rails_helper.gemspec
+++ b/foundation_rails_helper.gemspec
@@ -34,5 +34,5 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency 'rspec-rails', '>= 3.1'
   gem.add_development_dependency 'mime-types',  '~> 2'
-  gem.add_development_dependency 'capybara',    '~> 2.6.0'
+  gem.add_development_dependency 'capybara',    '~> 2.7'
 end

--- a/spec/foundation_rails_helper/form_builder_spec.rb
+++ b/spec/foundation_rails_helper/form_builder_spec.rb
@@ -177,7 +177,7 @@ describe "FoundationRailsHelper::FormHelper" do
       it "wraps input in the div with the right column size" do
         expect(@node.find('.row.collapse')).to have_css('div.small-8.medium-6.large-4.columns')
       end
-      
+
     end
   end
 
@@ -283,7 +283,7 @@ describe "FoundationRailsHelper::FormHelper" do
     it "should generate check_box input" do
       form_for(@author) do |builder|
         node = Capybara.string builder.check_box(:active)
-        expect(node).to have_css('label[for="author_active"] input[type="hidden"][name="author[active]"][value="0"]')
+        expect(node).to have_css('label[for="author_active"] input[type="hidden"][name="author[active]"][value="0"]', :visible => false)
         expect(node).to have_css('label[for="author_active"] input[type="checkbox"][name="author[active]"]')
         expect(node).to have_css('label[for="author_active"]', :text => "Active")
       end
@@ -291,7 +291,7 @@ describe "FoundationRailsHelper::FormHelper" do
     it "should generate check_box input without a label" do
       form_for(@author) do |builder|
         node = Capybara.string builder.check_box(:active, :label => false)
-        expect(node).to have_css('input[type="hidden"][name="author[active]"][value="0"]')
+        expect(node).to have_css('input[type="hidden"][name="author[active]"][value="0"]', :visible => false)
         expect(node).to have_css('input[type="checkbox"][name="author[active]"]')
         expect(node).to_not have_css('label[for="author_active"]')
       end


### PR DESCRIPTION
Capybara 2.7 introduces behaviour whereby hidden elements are not
recognised (this is sensible since users do not normally interact with
hidden elements).

This caused a problem for a couple of our specs which asserted the
presence of hidden elements.

https://github.com/sgruhier/foundation_rails_helper/pull/133 locked capybara to 2.6 because of failing specs. This PR fixes the failing specs and updates to `~>2.7`