### PR TITLE
Prevent Travis building twice on PRs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: ruby
+branches:
+  only:
+    - master
 rvm:
   - 1.9.3
   - 2.1.9


### PR DESCRIPTION
Currently we have both 'build pushes' (build all pushed commits) and
'build PRs' enabled.

This means that for each commit pushed to a PR, the whole thing is built
twice, identically in Travis.

This commit restricts push commits to just those made directly to the
master branch.

Source:
https://stackoverflow.com/questions/31882306/how-to-configure-travis-ci-to-build-pull-requests-merges-to-master-w-o-redunda