### PR TITLE
action view extension cleanup

### DIFF
--- a/lib/foundation_rails_helper/action_view_extension.rb
+++ b/lib/foundation_rails_helper/action_view_extension.rb
@@ -3,15 +3,12 @@ module ActionView
     module FormHelper
       def form_for_with_foundation(record, options = {}, &block)
         options[:builder] ||= FoundationRailsHelper::FormBuilder
-        options[:html] ||= {}
         options[:auto_labels] = true unless options.has_key? :auto_labels
         form_for_without_foundation(record, options, &block)
       end
 
       def fields_for_with_foundation(record_name, record_object = nil, options = {}, &block)
         options[:builder] ||= FoundationRailsHelper::FormBuilder
-        options[:html] ||= {}
-        options[:html][:attached_labels] = options[:attached_labels]
         options[:auto_labels] = true unless options.has_key? :auto_labels
         fields_for_without_foundation(record_name, record_object, options, &block)
       end

--- a/lib/foundation_rails_helper/action_view_extension.rb
+++ b/lib/foundation_rails_helper/action_view_extension.rb
@@ -1,21 +1,4 @@
-module ActionView
-  module Helpers
-    module FormHelper
-      def form_for_with_foundation(record, options = {}, &block)
-        options[:builder] ||= FoundationRailsHelper::FormBuilder
-        form_for_without_foundation(record, options, &block)
-      end
-
-      def fields_for_with_foundation(record_name, record_object = nil, options = {}, &block)
-        options[:builder] ||= FoundationRailsHelper::FormBuilder
-        fields_for_without_foundation(record_name, record_object, options, &block)
-      end
-
-      alias_method_chain :form_for, :foundation
-      alias_method_chain :fields_for, :foundation
-    end
-  end
-end
+ActionView::Base.default_form_builder = FoundationRailsHelper::FormBuilder
 ActionView::Base.field_error_proc = Proc.new do |html_tag, instance_tag|
   html_tag
 end

--- a/lib/foundation_rails_helper/action_view_extension.rb
+++ b/lib/foundation_rails_helper/action_view_extension.rb
@@ -3,13 +3,11 @@ module ActionView
     module FormHelper
       def form_for_with_foundation(record, options = {}, &block)
         options[:builder] ||= FoundationRailsHelper::FormBuilder
-        options[:auto_labels] = true unless options.has_key? :auto_labels
         form_for_without_foundation(record, options, &block)
       end
 
       def fields_for_with_foundation(record_name, record_object = nil, options = {}, &block)
         options[:builder] ||= FoundationRailsHelper::FormBuilder
-        options[:auto_labels] = true unless options.has_key? :auto_labels
         fields_for_without_foundation(record_name, record_object, options, &block)
       end
 

--- a/lib/foundation_rails_helper/form_builder.rb
+++ b/lib/foundation_rails_helper/form_builder.rb
@@ -214,7 +214,8 @@ module FoundationRailsHelper
     end
 
     def field(attribute, options, html_options = nil, &block)
-      if @options[:auto_labels] || options[:label]
+      auto_labels = @options.fetch(:auto_labels, true)
+      if auto_labels || options[:label]
         html = custom_label(attribute, options[:label], options[:label_options])
       else
         html = ''.html_safe

--- a/lib/foundation_rails_helper/form_builder.rb
+++ b/lib/foundation_rails_helper/form_builder.rb
@@ -214,7 +214,7 @@ module FoundationRailsHelper
     end
 
     def field(attribute, options, html_options = nil, &block)
-      auto_labels = @options.fetch(:auto_labels, true)
+      auto_labels = true unless @options[:auto_labels] == false
       if auto_labels || options[:label]
         html = custom_label(attribute, options[:label], options[:label_options])
       else

--- a/spec/foundation_rails_helper/form_builder_spec.rb
+++ b/spec/foundation_rails_helper/form_builder_spec.rb
@@ -20,6 +20,13 @@ describe "FoundationRailsHelper::FormHelper" do
     end
   end
 
+  it "should display labels if auto_labels: true is set" do
+    form_for(@author, auto_labels: true) do |builder|
+      node = Capybara.string builder.text_field(:login)
+      expect(node).to have_css('label[for="author_login"]', :text => "Login")
+    end
+  end
+
   it "should display labels if there are options without auto_labels: false" do
     form_for(@author, {html: {class: 'myclass'}}) do |builder|
       node = Capybara.string builder.text_field(:login)
@@ -31,6 +38,20 @@ describe "FoundationRailsHelper::FormHelper" do
     form_for(@author, {html: {class: 'myclass'}, auto_labels: false}) do |builder|
       node = Capybara.string builder.text_field(:login)
       expect(node).to_not have_css('label[for="author_login"]', :text => "Login")
+    end
+  end
+
+  it "should display labels if :auto_labels is set to nil" do
+    form_for(@author, auto_labels: nil) do |builder|
+      node = Capybara.string builder.text_field(:login)
+      expect(node).to have_css('label[for="author_login"]', :text => "Login")
+    end
+  end
+
+  it "should display labels if :auto_labels is set to a string" do
+    form_for(@author, auto_labels: "false") do |builder|
+      node = Capybara.string builder.text_field(:login)
+      expect(node).to have_css('label[for="author_login"]', :text => "Login")
     end
   end
 

--- a/spec/foundation_rails_helper/form_builder_spec.rb
+++ b/spec/foundation_rails_helper/form_builder_spec.rb
@@ -20,14 +20,14 @@ describe "FoundationRailsHelper::FormHelper" do
     end
   end
 
-  it "should not display labels by if there are options without auto_labels: false" do
+  it "should display labels if there are options without auto_labels: false" do
     form_for(@author, {html: {class: 'myclass'}}) do |builder|
       node = Capybara.string builder.text_field(:login)
       expect(node).to have_css('label[for="author_login"]', :text => "Login")
     end
   end
 
-  it "should not display labels by if there are options without auto_labels: false" do
+  it "should not display labels if there are options with auto_labels: false" do
     form_for(@author, {html: {class: 'myclass'}, auto_labels: false}) do |builder|
       node = Capybara.string builder.text_field(:login)
       expect(node).to_not have_css('label[for="author_login"]', :text => "Login")


### PR DESCRIPTION
Fixes #131 

- Removes `alias_method_chain`
- Fixes a separate bug whereby `auto_labels: nil` would be interpreted as false rather than true