### PR TITLE
Change input hint to help text

### DIFF
--- a/lib/foundation_rails_helper/flash_helper.rb
+++ b/lib/foundation_rails_helper/flash_helper.rb
@@ -2,22 +2,25 @@ require 'action_view/helpers'
 
 module FoundationRailsHelper
   module FlashHelper
-    # <div class="alert-box [success alert secondary]">
+    # <div class="callout [success alert secondary]" data-closable>
     #   This is an alert box.
-    #   <a href="" class="close">&times;</a>
+    #   <button name="button" type="submit" class="close-button" data-close="">
+    #     <span>&times;</span>
+    #   </button>
     # </div>
     DEFAULT_KEY_MATCHING = {
       :alert     => :alert,
       :notice    => :success,
-      :info      => :info,
+      :info      => :primary,
       :secondary => :secondary,
       :success   => :success,
       :error     => :alert,
-      :warning   => :warning
+      :warning   => :warning,
+      :primary   => :primary
     }
     def display_flash_messages(key_matching = {})
       key_matching = DEFAULT_KEY_MATCHING.merge(key_matching)
-      key_matching.default = :standard
+      key_matching.default = :primary
 
       capture do
         flash.each do |key, value|
@@ -31,15 +34,25 @@ module FoundationRailsHelper
   private
 
     def alert_box(value, alert_class)
-      content_tag :div, :data => { :alert => "" }, :class => "alert-box #{alert_class}" do
+      content_tag(
+        :div,
+        :class => "callout #{alert_class}",
+        :data => { closable: '' }
+      ) do
         concat value
         concat close_link
       end
     end
 
     def close_link
-      link_to("&times;".html_safe, "#", :class => :close)
+      button_tag(
+        :class => 'close-button',
+        :type => 'button',
+        :data => { :close => '' },
+        :aria => { :label => 'Dismiss alert' }
+      ) do
+        content_tag(:span, '&times;'.html_safe, :aria => { :hidden => true })
+      end
     end
-
   end
 end

--- a/lib/foundation_rails_helper/flash_helper.rb
+++ b/lib/foundation_rails_helper/flash_helper.rb
@@ -36,7 +36,7 @@ module FoundationRailsHelper
     def alert_box(value, alert_class)
       content_tag(
         :div,
-        :class => "callout #{alert_class}",
+        :class => "flash callout #{alert_class}",
         :data => { closable: '' }
       ) do
         concat value

--- a/lib/foundation_rails_helper/form_builder.rb
+++ b/lib/foundation_rails_helper/form_builder.rb
@@ -19,7 +19,7 @@ module FoundationRailsHelper
     def label(attribute, text = nil, options = {})
       if has_error?(attribute)
         options[:class] ||= ''
-        options[:class] += ' error'
+        options[:class] += ' is-invalid-label'
       end
 
       super(attribute, (text || '').html_safe, options)
@@ -114,14 +114,14 @@ module FoundationRailsHelper
     end
 
     def error_for(attribute, options = {})
-      class_name = 'error'
+      class_name = 'form-error is-visible'
       class_name += " #{options[:class]}" if options[:class]
 
       return unless has_error?(attribute)
 
       error_messages = object.errors[attribute].join(', ')
       error_messages = error_messages.html_safe if options[:html_safe_errors]
-      content_tag(:small, error_messages, :class => class_name)
+      content_tag(:small, error_messages, :class => class_name.sub('is-invalid-input', ''))
     end
 
     def custom_label(attribute, text, options, &block)
@@ -224,7 +224,7 @@ module FoundationRailsHelper
 
       if has_error?(attribute)
         class_options[:class] = class_options[:class].to_s
-        class_options[:class] += ' error'
+        class_options[:class] += ' is-invalid-input'
       end
 
       options.delete(:label)

--- a/lib/foundation_rails_helper/form_builder.rb
+++ b/lib/foundation_rails_helper/form_builder.rb
@@ -30,7 +30,7 @@ module FoundationRailsHelper
         options.delete(:label)
         options.delete(:label_options)
         super(attribute, options, checked_value, unchecked_value)
-      end + error_and_hint(attribute, options)
+      end + error_and_help_text(attribute, options)
     end
 
     def radio_button(attribute, tag_value, options = {})
@@ -204,10 +204,10 @@ module FoundationRailsHelper
       html.html_safe
     end
 
-    def error_and_hint(attribute, options = {})
+    def error_and_help_text(attribute, options = {})
       html = ''
-      if options[:hint]
-        html += content_tag(:span, options[:hint], :class => :hint)
+      if options[:help_text]
+        html += content_tag(:p, options[:help_text], class: 'help-text')
       end
       html += error_for(attribute, options) || ''
       html.html_safe
@@ -229,12 +229,12 @@ module FoundationRailsHelper
 
       options.delete(:label)
       options.delete(:label_options)
-      hint = options.delete(:hint)
+      help_text = options.delete(:help_text)
       prefix = options.delete(:prefix)
       postfix = options.delete(:postfix)
 
       html += wrap_prefix_and_postfix(yield(class_options), prefix, postfix)
-      html + error_and_hint(attribute, options.merge(hint: hint))
+      html + error_and_help_text(attribute, options.merge(help_text: help_text))
     end
   end
 end

--- a/spec/foundation_rails_helper/flash_helper_spec.rb
+++ b/spec/foundation_rails_helper/flash_helper_spec.rb
@@ -15,7 +15,7 @@ describe FoundationRailsHelper::FlashHelper do
       allow(self).to receive(:flash).and_return({message_type.to_s => "Flash message"})
       node = Capybara.string display_flash_messages
       expect(node).
-        to  have_css("div.callout.#{foundation_type}", :text => "Flash message").
+        to  have_css("div.flash.callout.#{foundation_type}", :text => "Flash message").
         and have_css("[data-close]", :text => "×")
     end
   end

--- a/spec/foundation_rails_helper/flash_helper_spec.rb
+++ b/spec/foundation_rails_helper/flash_helper_spec.rb
@@ -7,6 +7,7 @@ describe FoundationRailsHelper::FlashHelper do
   include ActionView::Helpers::UrlHelper
   include ActionView::Helpers::TagHelper
   include ActionView::Helpers::TextHelper
+  include ActionView::Helpers::FormTagHelper
   include FoundationRailsHelper::FlashHelper
 
   FoundationRailsHelper::FlashHelper::DEFAULT_KEY_MATCHING.each do |message_type, foundation_type|
@@ -14,47 +15,47 @@ describe FoundationRailsHelper::FlashHelper do
       allow(self).to receive(:flash).and_return({message_type.to_s => "Flash message"})
       node = Capybara.string display_flash_messages
       expect(node).
-        to  have_css("div.alert-box.#{foundation_type}", :text => "Flash message").
-        and have_css("div.alert-box a.close", :text => "×")
+        to  have_css("div.callout.#{foundation_type}", :text => "Flash message").
+        and have_css("[data-close]", :text => "×")
     end
   end
 
   it "handles symbol keys" do
     allow(self).to receive(:flash).and_return({ :success => "Flash message" })
     node = Capybara.string display_flash_messages
-    expect(node).to have_css("div.alert-box.success", :text => "Flash message")
+    expect(node).to have_css("div.callout.success", :text => "Flash message")
   end
 
   it "handles string keys" do
     allow(self).to receive(:flash).and_return({ "success" => "Flash message" })
     node = Capybara.string display_flash_messages
-    expect(node).to have_css("div.alert-box.success", :text => "Flash message")
+    expect(node).to have_css("div.callout.success", :text => "Flash message")
   end
 
   it "displays multiple flash messages" do
     allow(self).to receive(:flash).and_return({ "success" => "Yay it worked", "error" => "But this other thing failed" })
     node = Capybara.string display_flash_messages
     expect(node).
-      to  have_css("div.alert-box.success", :text => "Yay it worked").
-      and have_css("div.alert-box.alert",   :text => "But this other thing failed")
+      to  have_css("div.callout.success", :text => "Yay it worked").
+      and have_css("div.callout.alert",   :text => "But this other thing failed")
   end
 
   it "displays flash message with overridden key matching" do
     allow(self).to receive(:flash).and_return({ "notice" => "Flash message" })
     node = Capybara.string display_flash_messages({:notice => :alert})
-    expect(node).to have_css("div.alert-box.alert", :text => "Flash message")
+    expect(node).to have_css("div.callout.alert", :text => "Flash message")
   end
 
   it "displays flash message with custom key matching" do
     allow(self).to receive(:flash).and_return({ "custom_type" => "Flash message" })
     node = Capybara.string display_flash_messages({:custom_type => :custom_class})
-    expect(node).to have_css("div.alert-box.custom_class", :text => "Flash message")
+    expect(node).to have_css("div.callout.custom_class", :text => "Flash message")
   end
 
   it "displays flash message with standard class if key doesn't match" do
     allow(self).to receive(:flash).and_return({ "custom_type" => "Flash message" })
     node = Capybara.string display_flash_messages
-    expect(node).to have_css("div.alert-box.standard", :text => "Flash message")
+    expect(node).to have_css("div.callout.primary", :text => "Flash message")
   end
 
   context "when the flash hash contains devise internal data" do
@@ -75,7 +76,7 @@ describe FoundationRailsHelper::FlashHelper do
 
       # Ideally we'd create a node using Capybara.string, as in the other examples
       # and set the following expectation:
-      #   expect(node).to_not have_css("div.alert-box")
+      #   expect(node).to_not have_css("div.callout")
       # but Capybara.string doesn't behave nicely with nil input:
       # the input gets assigned to the @native instance variable,
       # which is used by the css matcher, so we get the following error:

--- a/spec/foundation_rails_helper/form_builder_spec.rb
+++ b/spec/foundation_rails_helper/form_builder_spec.rb
@@ -510,19 +510,19 @@ describe "FoundationRailsHelper::FormHelper" do
       end
     end
 
-    describe "hint" do
-      it "should add a span element" do
+    describe "help_text" do
+      it "should add a p element" do
         form_for(@author) do |builder|
-          hint = 'Enter login'
-          node = Capybara.string builder.text_field(:login, :hint => hint)
-          expect(node.find("span").text).to eq hint
+          help_text = 'Enter login'
+          node = Capybara.string builder.text_field(:login, help_text: help_text)
+          expect(node.find("p").text).to eq help_text
         end
       end
 
-      it "should not add hint attribute" do
+      it "should not add help_text attribute" do
         form_for(@author) do |builder|
-          node = Capybara.string builder.text_field(:login, :hint => 'Enter login')
-          expect(node.find_field("author_login")['hint']).to be_nil
+          node = Capybara.string builder.text_field(:login, :help_text => 'Enter login')
+          expect(node.find_field("author_login")['help_text']).to be_nil
         end
       end
     end

--- a/spec/foundation_rails_helper/form_builder_spec.rb
+++ b/spec/foundation_rails_helper/form_builder_spec.rb
@@ -69,7 +69,7 @@ describe "FoundationRailsHelper::FormHelper" do
       form_for(@author) do |builder|
         allow(@author).to receive(:errors).and_return({:login => ['required']})
         node = Capybara.string builder.text_field(:login)
-        error_class = node.find('label')['class'].split(/\s+/).keep_if { |v| v == 'error' }
+        error_class = node.find('label')['class'].split(/\s+/).keep_if { |v| v == 'is-invalid-label' }
         expect(error_class.size).to eq 1
       end
     end
@@ -541,14 +541,14 @@ describe "FoundationRailsHelper::FormHelper" do
     it "should not display errors" do
       form_for(@author) do |builder|
         node = Capybara.string builder.text_field(:login)
-        expect(node).to_not have_css('small.error')
+        expect(node).to_not have_css('small.form-error')
       end
     end
     it "should display errors" do
       form_for(@author) do |builder|
         allow(@author).to receive(:errors).and_return({:login => ['required']})
         node = Capybara.string builder.text_field(:login)
-        expect(node).to have_css('small.error', :text => "required")
+        expect(node).to have_css('small.form-error', :text => "required")
       end
     end
     %w(file_field email_field text_field telephone_field phone_field
@@ -561,8 +561,8 @@ describe "FoundationRailsHelper::FormHelper" do
         form_for(@author) do |builder|
           allow(@author).to receive(:errors).and_return({:description => ['required']})
           node = Capybara.string builder.public_send(field, :description)
-          expect(node).to have_css('label.error[for="author_description"]')
-          expect(node).to have_css('input.error[name="author[description]"]')
+          expect(node).to have_css('label.is-invalid-label[for="author_description"]')
+          expect(node).to have_css('input.is-invalid-input[name="author[description]"]')
         end
       end
     end
@@ -570,40 +570,40 @@ describe "FoundationRailsHelper::FormHelper" do
       form_for(@author) do |builder|
         allow(@author).to receive(:errors).and_return({:description => ['required']})
         node = Capybara.string builder.text_area(:description)
-        expect(node).to have_css('label.error[for="author_description"]')
-        expect(node).to have_css('textarea.error[name="author[description]"]')
+        expect(node).to have_css('label.is-invalid-label[for="author_description"]')
+        expect(node).to have_css('textarea.is-invalid-input[name="author[description]"]')
       end
     end
     it "should display errors on select inputs" do
       form_for(@author) do |builder|
         allow(@author).to receive(:errors).and_return({:favorite_book => ['required']})
         node = Capybara.string builder.select(:favorite_book, [["Choice #1", :a], ["Choice #2", :b]])
-        expect(node).to have_css('label.error[for="author_favorite_book"]')
-        expect(node).to have_css('select.error[name="author[favorite_book]"]')
+        expect(node).to have_css('label.is-invalid-label[for="author_favorite_book"]')
+        expect(node).to have_css('select.is-invalid-input[name="author[favorite_book]"]')
       end
     end
     it "should display errors on date_select inputs" do
       form_for(@author) do |builder|
         allow(@author).to receive(:errors).and_return({:birthdate => ['required']})
         node = Capybara.string builder.date_select(:birthdate)
-        expect(node).to have_css('label.error[for="author_birthdate"]')
-        %w(1 2 3).each {|i| expect(node).to have_css("select.error[name='author[birthdate(#{i}i)]']") }
+        expect(node).to have_css('label.is-invalid-label[for="author_birthdate"]')
+        %w(1 2 3).each {|i| expect(node).to have_css("select.is-invalid-input[name='author[birthdate(#{i}i)]']") }
       end
     end
     it "should display errors on datetime_select inputs" do
       form_for(@author) do |builder|
         allow(@author).to receive(:errors).and_return({:birthdate => ['required']})
         node = Capybara.string builder.datetime_select(:birthdate)
-        expect(node).to have_css('label.error[for="author_birthdate"]')
-        %w(1 2 3 4 5).each {|i| expect(node).to have_css("select.error[name='author[birthdate(#{i}i)]']") }
+        expect(node).to have_css('label.is-invalid-label[for="author_birthdate"]')
+        %w(1 2 3 4 5).each {|i| expect(node).to have_css("select.is-invalid-input[name='author[birthdate(#{i}i)]']") }
       end
     end
     it "should display errors on time_zone_select inputs"  do
       form_for(@author) do |builder|
         allow(@author).to receive(:errors).and_return({:time_zone => ['required']})
         node = Capybara.string builder.time_zone_select(:time_zone)
-        expect(node).to have_css('label.error[for="author_time_zone"]')
-        expect(node).to have_css('select.error[name="author[time_zone]"]')
+        expect(node).to have_css('label.is-invalid-label[for="author_time_zone"]')
+        expect(node).to have_css('select.is-invalid-input[name="author[time_zone]"]')
       end
     end
 
@@ -611,8 +611,8 @@ describe "FoundationRailsHelper::FormHelper" do
       form_for(@author) do |builder|
         allow(@author).to receive(:errors).and_return({:favorite_book => ['required']})
         node = Capybara.string builder.collection_select(:favorite_book, Book.all, :id, :title)
-        expect(node).to have_css('label.error[for="author_favorite_book"]')
-        expect(node).to have_css('select.error[name="author[favorite_book]"]')
+        expect(node).to have_css('label.is-invalid-label[for="author_favorite_book"]')
+        expect(node).to have_css('select.is-invalid-input[name="author[favorite_book]"]')
       end
     end
 
@@ -620,12 +620,12 @@ describe "FoundationRailsHelper::FormHelper" do
       form_for(@author) do |builder|
         allow(@author).to receive(:errors).and_return({:favorite_book => ['required']})
         node = Capybara.string builder.grouped_collection_select(:favorite_book, Genre.all, :books, :name, :id, :title)
-        expect(node).to have_css('label.error[for="author_favorite_book"]')
-        expect(node).to have_css('select.error[name="author[favorite_book]"]')
+        expect(node).to have_css('label.is-invalid-label[for="author_favorite_book"]')
+        expect(node).to have_css('select.is-invalid-input[name="author[favorite_book]"]')
       end
     end
 
-    # N.B. check_box and radio_button inputs don't have the error class applied
+    # N.B. check_box and radio_button inputs don't have the is-invalid-input class applied
 
     it "should display HTML errors when the option is specified" do
       form_for(@author) do |builder|
@@ -659,7 +659,7 @@ describe "FoundationRailsHelper::FormHelper" do
         form_for(@author) do |builder|
           allow(@author).to receive(:errors).and_return({:email => ['required']})
           node = Capybara.string builder.text_field(:email, class: 'righteous')
-          expect(node).to have_css('input.righteous.error[name="author[email]"]')
+          expect(node).to have_css('input.righteous.is-invalid-input[name="author[email]"]')
         end
       end
     end
@@ -669,7 +669,7 @@ describe "FoundationRailsHelper::FormHelper" do
         form_for(@author) do |builder|
           allow(@author).to receive(:errors).and_return({:email => ['required']})
           node = Capybara.string builder.text_field(:email, class: :illgotten)
-          expect(node).to have_css('input.illgotten.error[name="author[email]"]')
+          expect(node).to have_css('input.illgotten.is-invalid-input[name="author[email]"]')
         end
       end
     end


### PR DESCRIPTION
The text under the input has a different class so I changed the option
key and css class.

http://foundation.zurb.com/sites/docs/forms.html#help-text

Fixes #145