### PR TITLE
Adding closable keyword option to display_flash_messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ This will be used for Foundation 5 support
 
 ### Breaking changes:
 * Dropped support for Ruby 1.9.3
+* display_flash_messages now requires the key_matching hash to be prefixed with the keyword argument :key_matching
 
 ### Features:
 * Add Rubocop code style linting

--- a/lib/foundation_rails_helper/flash_helper.rb
+++ b/lib/foundation_rails_helper/flash_helper.rb
@@ -19,7 +19,15 @@ module FoundationRailsHelper
       primary:   :primary
     }.freeze
 
-    def display_flash_messages(key_matching = {})
+    # Displays the flash messages found in ActionDispatch's +flash+ hash using Foundation's
+    # +callout+ component.
+    #
+    # Parameters:
+    # * +closable+ - A boolean to determine whether the displayed flash messages should
+    #   be closable by the user. Defaults to true.
+    # * +key_matching+ - A Hash of key/value pairs mapping flash keys to the
+    #   corresponding class to use for the callout box.
+    def display_flash_messages(closable: true, key_matching: {})
       key_matching = DEFAULT_KEY_MATCHING.merge(key_matching)
       key_matching.default = :primary
 
@@ -27,21 +35,19 @@ module FoundationRailsHelper
         flash.each do |key, value|
           next if FoundationRailsHelper.configuration.ignored_flash_keys.include? key.to_sym
           alert_class = key_matching[key.to_sym]
-          concat alert_box(value, alert_class)
+          concat alert_box(value, alert_class, closable)
         end
       end
     end
 
     private
 
-    def alert_box(value, alert_class)
-      content_tag(
-        :div,
-        class: "flash callout #{alert_class}",
-        data: { closable: '' }
-      ) do
+    def alert_box(value, alert_class, closable)
+      options = { class: "flash callout #{alert_class}" }
+      options[:data] = { closable: '' } if closable
+      content_tag(:div, options) do
         concat value
-        concat close_link
+        concat close_link if closable
       end
     end
 

--- a/spec/foundation_rails_helper/flash_helper_spec.rb
+++ b/spec/foundation_rails_helper/flash_helper_spec.rb
@@ -42,13 +42,13 @@ describe FoundationRailsHelper::FlashHelper do
 
   it "displays flash message with overridden key matching" do
     allow(self).to receive(:flash).and_return("notice" => "Flash message")
-    node = Capybara.string display_flash_messages(notice: :alert)
+    node = Capybara.string display_flash_messages(key_matching: { notice: :alert })
     expect(node).to have_css("div.callout.alert", text: "Flash message")
   end
 
   it "displays flash message with custom key matching" do
     allow(self).to receive(:flash).and_return("custom_type" => "Flash message")
-    node = Capybara.string display_flash_messages(custom_type: :custom_class)
+    node = Capybara.string display_flash_messages(key_matching: { custom_type: :custom_class })
     expect(node).to have_css("div.callout.custom_class", text: "Flash message")
   end
 
@@ -81,6 +81,16 @@ describe FoundationRailsHelper::FlashHelper do
       # the input gets assigned to the @native instance variable,
       # which is used by the css matcher, so we get the following error:
       #   undefined method `css' for nil:NilClass
+    end
+  end
+
+  context "with (closable: false) option" do
+    it "doesn't display the close button" do
+      allow(self).to receive(:flash).and_return(success: "Flash message")
+      node = Capybara.string display_flash_messages(closable: false)
+      expect(node)
+        .to  have_css("div.flash.callout.success", text: "Flash message")
+        .and have_no_css("[data-close]", text: "×")
     end
   end
 end


### PR DESCRIPTION
Making a breaking change to display_flash_messages that requires the key_matching hash to be prefixed with the :key_matching keyword.

Adding the keyword option :closable to the display_flash_messages method that accepts a boolean true/false, defaulting to true.

If false, suppresses the close buttons on the callouts.