### PR TITLE
Foundation 5 - Fix version number

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Add this line to your application's Gemfile:
 
 ```ruby
 gem 'foundation-rails'
-gem 'foundation_rails_helper', '~> 1.2.0'
+gem 'foundation_rails_helper', '~> 2.0.0'
 ```
 
 And then execute:


### PR DESCRIPTION
The foundation-5 branch will use version 2.x.x, not 1.2.x