### PR TITLE
Gem version in the installation code

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Add this line to your application's Gemfile:
 
 ```ruby
 gem 'foundation-rails' # required
-gem 'foundation_rails_helper', '~> 3.0.0'
+gem 'foundation_rails_helper', '~> 2.0.0'
 ```
 
 And then execute:


### PR DESCRIPTION
The latest version released is the 2.0.0 but it is written 3.0.0 in the readme causing an issue when copy-pasting.