### PR TITLE
Fix label output in checkbox when labels have HTML

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -17,3 +17,6 @@ FrozenStringLiteralComment:
 
 Documentation:
   Enabled: false
+
+Style/VariableNumber:
+    EnforcedStyle: 'snake_case'

--- a/lib/foundation_rails_helper.rb
+++ b/lib/foundation_rails_helper.rb
@@ -1,6 +1,7 @@
 require 'foundation_rails_helper/version'
 require 'foundation_rails_helper/configuration'
 require 'foundation_rails_helper/form_builder'
+require 'foundation_rails_helper/size_class_calculator'
 require 'foundation_rails_helper/flash_helper'
 require 'foundation_rails_helper/action_view_extension'
 ActiveSupport.on_load(:action_view) do

--- a/lib/foundation_rails_helper/form_builder.rb
+++ b/lib/foundation_rails_helper/form_builder.rb
@@ -139,38 +139,8 @@ module FoundationRailsHelper
     end
 
     def column_classes(options)
-      classes = SizeClassCalcluator.new(options).classes
+      classes = SizeClassCalculator.new(options).classes
       classes + ' columns'
-    end
-
-    class SizeClassCalcluator
-      def initialize(size_options)
-        @small = size_options[:small]
-        @medium = size_options[:medium]
-        @large = size_options[:large]
-      end
-
-      def classes
-        [small_class, medium_class, large_class].compact.join(' ')
-      end
-
-      private
-
-      def small_class
-        "small-#{@small}" if valid_size(@small)
-      end
-
-      def medium_class
-        "medium-#{@medium}" if valid_size(@medium)
-      end
-
-      def large_class
-        "large-#{@large}" if valid_size(@large)
-      end
-
-      def valid_size(value)
-        value.present? && value.to_i < 12
-      end
     end
 
     def tag_from_options(name, options)

--- a/lib/foundation_rails_helper/form_builder.rb
+++ b/lib/foundation_rails_helper/form_builder.rb
@@ -3,6 +3,7 @@ require 'action_view/helpers'
 module FoundationRailsHelper
   class FormBuilder < ActionView::Helpers::FormBuilder
     include ActionView::Helpers::TagHelper
+    include ActionView::Helpers::OutputSafetyHelper
     %w(file_field email_field text_field text_area telephone_field phone_field
        url_field number_field date_field datetime_field datetime_local_field
        month_field week_field time_field range_field search_field color_field)
@@ -132,7 +133,7 @@ module FoundationRailsHelper
             attribute.to_s.humanize
           end
       end
-      text = yield.html_safe + " #{text}" if block_given?
+      text = safe_join([yield, text.html_safe]) if block_given?
       options ||= {}
       label(attribute, text, options)
     end

--- a/lib/foundation_rails_helper/size_class_calculator.rb
+++ b/lib/foundation_rails_helper/size_class_calculator.rb
@@ -1,0 +1,31 @@
+module FoundationRailsHelper
+  class SizeClassCalculator
+    def initialize(size_options)
+      @small = size_options[:small]
+      @medium = size_options[:medium]
+      @large = size_options[:large]
+    end
+
+    def classes
+      [small_class, medium_class, large_class].compact.join(' ')
+    end
+
+    private
+
+    def small_class
+      "small-#{@small}" if valid_size(@small)
+    end
+
+    def medium_class
+      "medium-#{@medium}" if valid_size(@medium)
+    end
+
+    def large_class
+      "large-#{@large}" if valid_size(@large)
+    end
+
+    def valid_size(value)
+      value.present? && value.to_i < 12
+    end
+  end
+end

--- a/spec/foundation_rails_helper/form_builder_spec.rb
+++ b/spec/foundation_rails_helper/form_builder_spec.rb
@@ -316,6 +316,12 @@ describe "FoundationRailsHelper::FormHelper" do
         expect(node).to_not have_css('label[for="author_active"]')
       end
     end
+    it "should generate check_box input with a label with HTML content" do
+      form_for(@author) do |builder|
+        node = Capybara.string builder.check_box(:active, label: "<a href='/'>Accepts terms and conditions</a>")
+        expect(node).to have_css('label[for="author_active"] a', text: "Accepts terms and conditions")
+      end
+    end
 
     it "should generate radio_button input" do
       form_for(@author) do |builder|


### PR DESCRIPTION
This PR fixes the case when you have a checkbox with a label that has HTML content (like an accept terms and conditions checkbox with a link to the terms), right now the label is not properly escaped and the link isn't marked as safe.

It also fixes some rubocop offenses so the build is green.