### PR TITLE
Set a max Rails version of 6.0

### DIFF
--- a/foundation_rails_helper.gemspec
+++ b/foundation_rails_helper.gemspec
@@ -5,7 +5,7 @@ class Gem::Specification # rubocop:disable ClassAndModuleChildren
   def self.rails_gem_version
     # Allow different versions of the rails gems to be specified, for testing
     @rails_gem_version ||=
-      ENV['RAILS_VERSION'] ? "~> #{ENV['RAILS_VERSION']}" : '>= 4.1'
+      ENV['RAILS_VERSION'] ? "~> #{ENV['RAILS_VERSION']}" : ['>= 4.1', '< 6.0']
   end
 end
 


### PR DESCRIPTION
To remove warning messages when building gem