### PR TITLE
Rails 6 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,20 +3,35 @@ branches:
   only:
     - master
 rvm:
-  - 2.1.9
-  - 2.2.5
-  - 2.3.1
-  - 2.4.0-preview1
+  - 2.1.10
+  - 2.2.10
+  - 2.3.8
+  - 2.4.7
+  - 2.5.6
+  - 2.6.4
 env:
-  - "RAILS_VERSION=4.1.0"
   - "RAILS_VERSION=4.2.0"
   - "RAILS_VERSION=5.0.0"
+  - "RAILS_VERSION=5.2.0"
+  - "RAILS_VERSION=6.0.0"
 matrix:
   exclude:
-    - rvm: 2.1.9
+    - rvm: 2.4.7
+      env: "RAILS_VERSION=6.0.0"
+    - rvm: 2.3.8
+      env: "RAILS_VERSION=6.0.0"
+    - rvm: 2.2.10
+      env: "RAILS_VERSION=6.0.0"
+    - rvm: 2.1.10
+      env: "RAILS_VERSION=6.0.0"
+    - rvm: 2.1.10
+      env: "RAILS_VERSION=5.2.0"
+    - rvm: 2.1.10
       env: "RAILS_VERSION=5.0.0"
-    - rvm: 2.4.0-preview1
-      env: "RAILS_VERSION=4.1.0"
-    - rvm: 2.4.0-preview1
+    - rvm: 2.4.7
+      env: "RAILS_VERSION=4.2.0"
+    - rvm: 2.5.6
+      env: "RAILS_VERSION=4.2.0"
+    - rvm: 2.6.4
       env: "RAILS_VERSION=4.2.0"
 sudo: false

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ $ bundle
 
 ## Compatibility
 
-* Only Rails 4.1/4.2/5, and Foundation 6 are fully supported
+* Only Rails 4.1/4.2/5/6, and Foundation 6 are fully supported
 * Some features may work with Foundation 5 and older, but results may vary, and markup which exists only for those versions will be gradually removed
 * Legacy branches exist for Rails 3, 4.0, and Foundation 5 (see the rails3, rails4.0, and foundation-5 branches). These are not actively supported, and fixes are not retroactively applied, but pull requests are welcome.
 * We test against ruby versions 2.1 and up. This gem may still work fine on 1.9.3, but your mileage may vary

--- a/foundation_rails_helper.gemspec
+++ b/foundation_rails_helper.gemspec
@@ -5,7 +5,7 @@ class Gem::Specification # rubocop:disable ClassAndModuleChildren
   def self.rails_gem_version
     # Allow different versions of the rails gems to be specified, for testing
     @rails_gem_version ||=
-      ENV['RAILS_VERSION'] ? "~> #{ENV['RAILS_VERSION']}" : ['>= 4.1', '< 6.0']
+      ENV['RAILS_VERSION'] ? "~> #{ENV['RAILS_VERSION']}" : ['>= 4.1', '< 7.0']
   end
 end
 

--- a/spec/support/mock_rails.rb
+++ b/spec/support/mock_rails.rb
@@ -10,7 +10,9 @@ module FoundationRailsSpecHelper
   include ActionView::Helpers::FormHelper
   include ActionView::Helpers::FormOptionsHelper
   include ActionView::Helpers::DateHelper
-  include ActionController::PolymorphicRoutes if defined?(ActionController::PolymorphicRoutes)
+  if defined?(ActionController::PolymorphicRoutes)
+    include ActionController::PolymorphicRoutes
+  end
   include ActionDispatch::Routing::PolymorphicRoutes
   include AbstractController::UrlFor if defined?(AbstractController::UrlFor)
   # to use dom_class in Rails 4 tests
@@ -57,9 +59,7 @@ module FoundationRailsSpecHelper
   end
 
   def _routes
-    double('_routes',
-      :polymorphic_mappings => {}
-    )
+    double('_routes', polymorphic_mappings: {})
   end
 
   def self.included(base)

--- a/spec/support/mock_rails.rb
+++ b/spec/support/mock_rails.rb
@@ -10,7 +10,9 @@ module FoundationRailsSpecHelper
   include ActionView::Helpers::FormHelper
   include ActionView::Helpers::FormOptionsHelper
   include ActionView::Helpers::DateHelper
-  include ActionDispatch::Routing::UrlFor
+  include ActionController::PolymorphicRoutes if defined?(ActionController::PolymorphicRoutes)
+  include ActionDispatch::Routing::PolymorphicRoutes
+  include AbstractController::UrlFor if defined?(AbstractController::UrlFor)
   # to use dom_class in Rails 4 tests
   # in Rails 5, RecordIdentifier is already required by FormHelper module
   include ActionView::RecordIdentifier
@@ -52,6 +54,12 @@ module FoundationRailsSpecHelper
   # the argument is required for Rails 4 tests
   def authors_path(*_args)
     '/authors'
+  end
+
+  def _routes
+    double('_routes',
+      :polymorphic_mappings => {}
+    )
   end
 
   def self.included(base)


### PR DESCRIPTION
I expanded the constraint in the gemspec to include Rails 6. There were a few changes to the spec setup that were needed in order for them to run on Rails 6, those changes were backward compatible  with Rails 4 and 5.

I also expanded  the Travis setup:

*  Removed Rails 4.1
*  Added Rails 5.2 and 6.0
*  Updated rubies 2.1 through 2.4 to the most recent patchlevel
*  Added ruby 2.5 and 2.6 for Rails 5 and 6 (6 _requires_ 2.5+)

I think one could be less generous on supported versions -- Rails 4.2 should be EOL now that Rails 6 is out, and ruby 2.2 has been EOL for a little over a year -- but I didn't want to presume.

I think the only thing left is to determine the version number and update the CHANGELOG. I didn't  technically remove Rails 4.1 support, but I did remove it from Travis.
