### PR TITLE
Remove dependency on tzinfo gem

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,9 @@ env:
   - "RAILS_VERSION=5.2.0"
   - "RAILS_VERSION=6.0.0"
   - "RAILS_VERSION=6.1.0"
-matrix:
+jobs:
   exclude:
-    - rvm: 2.4.7
+    - rvm: 2.4.10
       env: "RAILS_VERSION=6.1.0"
     - rvm: 2.3.8
       env: "RAILS_VERSION=6.1.0"
@@ -38,4 +38,3 @@ matrix:
       env: "RAILS_VERSION=4.2.0"
     - rvm: 2.4.10
       env: "RAILS_VERSION=4.2.0"
-sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,35 +3,39 @@ branches:
   only:
     - master
 rvm:
-  - 2.1.10
-  - 2.2.10
   - 2.3.8
-  - 2.4.7
-  - 2.5.6
-  - 2.6.4
+  - 2.4.10
+  - 2.5.8
+  - 2.6.6
+  - 2.7.2
 env:
   - "RAILS_VERSION=4.2.0"
   - "RAILS_VERSION=5.0.0"
   - "RAILS_VERSION=5.2.0"
   - "RAILS_VERSION=6.0.0"
+  - "RAILS_VERSION=6.1.0"
 matrix:
   exclude:
     - rvm: 2.4.7
+      env: "RAILS_VERSION=6.1.0"
+    - rvm: 2.3.8
+      env: "RAILS_VERSION=6.1.0"
+    - rvm: 2.7.2
+      env: "RAILS_VERSION=6.0.0"
+    - rvm: 2.4.10
       env: "RAILS_VERSION=6.0.0"
     - rvm: 2.3.8
       env: "RAILS_VERSION=6.0.0"
-    - rvm: 2.2.10
-      env: "RAILS_VERSION=6.0.0"
-    - rvm: 2.1.10
-      env: "RAILS_VERSION=6.0.0"
-    - rvm: 2.1.10
+    - rvm: 2.7.2
       env: "RAILS_VERSION=5.2.0"
-    - rvm: 2.1.10
+    - rvm: 2.7.2
       env: "RAILS_VERSION=5.0.0"
-    - rvm: 2.4.7
+    - rvm: 2.7.2
       env: "RAILS_VERSION=4.2.0"
-    - rvm: 2.5.6
+    - rvm: 2.6.6
       env: "RAILS_VERSION=4.2.0"
-    - rvm: 2.6.4
+    - rvm: 2.5.8
+      env: "RAILS_VERSION=4.2.0"
+    - rvm: 2.4.10
       env: "RAILS_VERSION=4.2.0"
 sudo: false

--- a/foundation_rails_helper.gemspec
+++ b/foundation_rails_helper.gemspec
@@ -30,7 +30,6 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'actionpack', Gem::Specification.rails_gem_version
   gem.add_dependency 'activemodel', Gem::Specification.rails_gem_version
   gem.add_dependency 'activesupport', Gem::Specification.rails_gem_version
-  gem.add_dependency 'tzinfo', '~> 1.2', '>= 1.2.2'
 
   gem.add_development_dependency 'rspec-rails', '~> 3.1'
   gem.add_development_dependency 'mime-types', '~> 2'

--- a/spec/foundation_rails_helper/form_builder_spec.rb
+++ b/spec/foundation_rails_helper/form_builder_spec.rb
@@ -763,8 +763,7 @@ describe "FoundationRailsHelper::FormHelper" do
     end
 
     %w(file_field email_field text_field telephone_field phone_field
-       url_field number_field date_field datetime_field datetime_local_field
-       month_field week_field time_field range_field search_field color_field
+       url_field number_field range_field search_field color_field
        password_field).each do |field|
       it "should display errors on #{field} inputs" do
         form_for(@author) do |builder|
@@ -775,6 +774,21 @@ describe "FoundationRailsHelper::FormHelper" do
             .to have_css('label.is-invalid-label[for="author_description"]')
           expect(node)
             .to have_css('input.is-invalid-input[name="author[description]"]')
+        end
+      end
+    end
+
+    %w(date_field datetime_field datetime_local_field month_field
+       week_field time_field).each do |field|
+      it "should display errors on #{field} inputs" do
+        form_for(@author) do |builder|
+          allow(@author)
+            .to receive(:errors).and_return(birthdate: ["required"])
+          node = Capybara.string builder.public_send(field, :birthdate)
+          expect(node)
+            .to have_css('label.is-invalid-label[for="author_birthdate"]')
+          expect(node)
+            .to have_css('input.is-invalid-input[name="author[birthdate]"]')
         end
       end
     end


### PR DESCRIPTION
Hello,

I was working on updating my app to Rails 6.1 and noticed that this gem's version dependency on the "tzinfo" gem was holding me back.

I couldn't see anything in the code that relied on tzinfo — doing some code archaeology, the dependency appears to have been added to keep compatibility with Rails 3 while adding Rails 4 support (and has been periodically bumped since then) — so, I removed the requirement.

While I was here, I updated the Travis config to include Rails 6.1, added Ruby 2.7 to the matrix where supported, and removed Rubies 2.1 and 2.2 which have been EOL for a few years now.

I also found some test failures in Rails 6.1 when using `date_field`, `time_field`, etc. with non-date attributes. Seemed like a thing a "real person" wouldn't do, so I just changed the test.