### PR TITLE
Bump version to 4.0.1

### DIFF
--- a/lib/foundation_rails_helper/version.rb
+++ b/lib/foundation_rails_helper/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module FoundationRailsHelper
-  VERSION = '3.0.0'
+  VERSION = '4.0.1'
 end


### PR DESCRIPTION
Bumping the gem version to 4.0.1. to emphasize the rails 7 support. 

@sgruhier, can you also make the release available in ruby gems as well?