### PR TITLE
Allow overriding the autocomplete attribute on `password_field`

### DIFF
--- a/lib/foundation_rails_helper/form_builder.rb
+++ b/lib/foundation_rails_helper/form_builder.rb
@@ -50,7 +50,8 @@ module FoundationRailsHelper
 
     def password_field(attribute, options = {})
       field attribute, options do |opts|
-        super(attribute, opts.merge(autocomplete: :off))
+        opts[:autocomplete] ||= :off
+        super(attribute, opts)
       end
     end
 

--- a/lib/foundation_rails_helper/form_builder.rb
+++ b/lib/foundation_rails_helper/form_builder.rb
@@ -70,8 +70,8 @@ module FoundationRailsHelper
     # rubocop:disable LineLength
     def time_zone_select(attribute, priorities = nil, options = {}, html_options = {})
       field attribute, options, html_options do |html_opts|
-        super(attribute, priorities, options,
-              html_opts.merge(autocomplete: :off))
+        html_options[:autocomplete] ||= :off
+        super(attribute, priorities, options, html_opts)
       end
     end
     # rubocop:enable LineLength

--- a/lib/foundation_rails_helper/form_builder.rb
+++ b/lib/foundation_rails_helper/form_builder.rb
@@ -57,7 +57,8 @@ module FoundationRailsHelper
 
     def datetime_select(attribute, options = {}, html_options = {})
       field attribute, options, html_options do |html_opts|
-        super(attribute, options, html_opts.merge(autocomplete: :off))
+        html_options[:autocomplete] ||= :off
+        super(attribute, options, html_opts)
       end
     end
 

--- a/lib/foundation_rails_helper/form_builder.rb
+++ b/lib/foundation_rails_helper/form_builder.rb
@@ -63,7 +63,8 @@ module FoundationRailsHelper
 
     def date_select(attribute, options = {}, html_options = {})
       field attribute, options, html_options do |html_opts|
-        super(attribute, options, html_opts.merge(autocomplete: :off))
+        html_options[:autocomplete] ||= :off
+        super(attribute, options, html_opts)
       end
     end
 

--- a/spec/foundation_rails_helper/form_builder_spec.rb
+++ b/spec/foundation_rails_helper/form_builder_spec.rb
@@ -574,7 +574,7 @@ describe "FoundationRailsHelper::FormHelper" do
         )
         expect(node)
           .to have_css('label[for="author_time_zone"]', text: "Time zone")
-        expect(node).to have_css('select[name="author[time_zone]"]')
+        expect(node).to have_css('select[name="author[time_zone]"][autocomplete="off"]')
         expect(node)
           .to have_css('select[name="author[time_zone]"] option[value="Perth"]',
                        text: "(GMT+08:00) Perth")

--- a/spec/foundation_rails_helper/form_builder_spec.rb
+++ b/spec/foundation_rails_helper/form_builder_spec.rb
@@ -289,7 +289,7 @@ describe "FoundationRailsHelper::FormHelper" do
         expect(node)
           .to have_css('label[for="author_password"]', text: "Password")
         expect(node)
-          .to have_css('input[type="password"][name="author[password]"]')
+          .to have_css('input[type="password"][name="author[password]"][autocomplete="off"]')
         expect(node.find_field("author_password").value).to be_nil
       end
     end

--- a/spec/foundation_rails_helper/form_builder_spec.rb
+++ b/spec/foundation_rails_helper/form_builder_spec.rb
@@ -294,6 +294,21 @@ describe "FoundationRailsHelper::FormHelper" do
       end
     end
 
+    context "when autocomplete attribute is defined in password_field input" do
+      let(:options) { { autocomplete: "new-password" } }
+
+      it "generates password_field input with autocomplete attribute" do
+        form_for(@author) do |builder|
+          node = Capybara.string builder.password_field(:password, options)
+          expect(node)
+            .to have_css('label[for="author_password"]', text: "Password")
+          expect(node)
+            .to have_css('input[type="password"][name="author[password]"][autocomplete="new-password"]')
+          expect(node.find_field("author_password").value).to be_nil
+        end
+      end
+    end
+
     it "should generate email_field input" do
       form_for(@author) do |builder|
         node = Capybara.string builder.email_field(:email)

--- a/spec/foundation_rails_helper/form_builder_spec.rb
+++ b/spec/foundation_rails_helper/form_builder_spec.rb
@@ -483,7 +483,7 @@ describe "FoundationRailsHelper::FormHelper" do
         expect(node)
           .to have_css('label[for="author_birthdate"]', text: "Birthdate")
         %w(1 2 3).each do |i|
-          expect(node).to have_css("select[name='author[birthdate(#{i}i)]']")
+          expect(node).to have_css("select[name='author[birthdate(#{i}i)]'][autocomplete='off']")
         end
         expect(node)
           .to have_css("#{select}1i #{option}[value=\"1969\"]")

--- a/spec/foundation_rails_helper/form_builder_spec.rb
+++ b/spec/foundation_rails_helper/form_builder_spec.rb
@@ -534,7 +534,7 @@ describe "FoundationRailsHelper::FormHelper" do
         expect(node)
           .to have_css('label[for="author_birthdate"]', text: "Birthdate")
         %w(1 2 3 4 5).each do |i|
-          expect(node).to have_css("select[name='author[birthdate(#{i}i)]']")
+          expect(node).to have_css("select[name='author[birthdate(#{i}i)]'][autocomplete='off']")
         end
         expect(node).to have_css("#{select}1i #{option}[value=\"1969\"]")
         expect(node).to have_css("#{select}2i #{option}[value=\"6\"]")


### PR DESCRIPTION
#### Description

This PR allows to override the `autocomplete` attribute default value on the `password_field`.

Also, this PR contains a light refactor on the `autocomplete` default value for the `time_zone_select`, `date_select`, `datetime_select` to be homogeneous with fields `select`, `collection_select` and `grouped_collection_select`

#### Done 

- [x] Add tests
- [x] Ensure tests are valids
- [ ] Rubocop linting (See comment below)

#### Resources
* [Autocomplete browser compatibilities](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete#browser_compatibility)

#### Additional informations

Thanks for this project ! I remain available for any questions. 